### PR TITLE
chore: add additional rules for _fieldExample

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -253,3 +253,14 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
 end_of_line = crlf
+
+# Use underscores for private fields
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = internal, protected_internal, private 
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+dotnet_naming_rule.private_fields_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_fields_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_fields_with_underscore.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -258,7 +258,7 @@ end_of_line = crlf
 dotnet_naming_symbols.private_fields.applicable_kinds           = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities = internal, protected_internal, private 
 
-dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.capitalization  = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
 
 dotnet_naming_rule.private_fields_with_underscore.symbols  = private_fields


### PR DESCRIPTION
Added additional rules to make _fieldExample not a warning but the default for internal, private, and protected_internal settings.