### PR TITLE
fix: update heuristics properly

### DIFF
--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -40,7 +40,7 @@ namespace Aplib.Core.Desire.Goals
         public CompletionStatus Status { get; protected set; }
 
         /// <summary>
-        /// The goal is considered to be completed, when the distance of the <see cref="CurrentHeuristics" /> is below
+        /// The goal is considered to be completed, when the distance of the <see cref="DetermineCurrentHeuristics" /> is below
         /// this value.
         /// </summary>
         protected double _epsilon { get; }
@@ -57,7 +57,7 @@ namespace Aplib.Core.Desire.Goals
         /// <param name="tactic">The tactic used to approach this goal.</param>
         /// <param name="heuristicFunction">The heuristic function which defines whether a goal is reached</param>
         /// <param name="epsilon">
-        /// The goal is considered to be completed, when the distance of the <see cref="CurrentHeuristics" /> is below
+        /// The goal is considered to be completed, when the distance of the <see cref="DetermineCurrentHeuristics" /> is below
         /// this value.
         /// </param>
         /// <param name="metadata">
@@ -83,7 +83,7 @@ namespace Aplib.Core.Desire.Goals
         /// <param name="tactic">The tactic used to approach this goal.</param>
         /// <param name="predicate">The heuristic function (or specifically predicate) which defines whether a goal is reached</param>
         /// <param name="epsilon">
-        /// The goal is considered to be completed, when the distance of the <see cref="CurrentHeuristics" /> is below
+        /// The goal is considered to be completed, when the distance of the <see cref="DetermineCurrentHeuristics" /> is below
         /// this value.
         /// </param>
         /// <param name="metadata">
@@ -101,18 +101,18 @@ namespace Aplib.Core.Desire.Goals
         /// Gets the <see cref="Heuristics" /> of the current state of the game.
         /// </summary>
         /// <remarks>If no heuristics have been calculated yet, they will be calculated first.</remarks>
-        public virtual Heuristics CurrentHeuristics(TBeliefSet beliefSet) => _heuristicFunction.Invoke(beliefSet);
+        public virtual Heuristics DetermineCurrentHeuristics(TBeliefSet beliefSet) => _heuristicFunction.Invoke(beliefSet);
 
         /// <summary>
         /// Tests whether the goal has been achieved, bases on the <see cref="_heuristicFunction" /> and the
-        /// <see cref="CurrentHeuristics" />. When the distance of the heuristics is smaller than <see cref="_epsilon" />,
+        /// <see cref="DetermineCurrentHeuristics" />. When the distance of the heuristics is smaller than <see cref="_epsilon" />,
         /// the goal is considered to be completed.
         /// </summary>
         /// <returns>An enum representing whether the goal is complete and if so, with what result.</returns>
         /// <seealso cref="_epsilon" />
         public virtual CompletionStatus GetStatus(TBeliefSet beliefSet)
         {
-            Status = CurrentHeuristics(beliefSet).Distance < _epsilon
+            Status = DetermineCurrentHeuristics(beliefSet).Distance < _epsilon
                 ? CompletionStatus.Success
                 : CompletionStatus.Unfinished;
             return Status;

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -52,11 +52,6 @@ namespace Aplib.Core.Desire.Goals
         protected HeuristicFunction _heuristicFunction;
 
         /// <summary>
-        /// The backing field of <see cref="Heuristics" />.
-        /// </summary>
-        private Heuristics? _currentHeuristics;
-
-        /// <summary>
         /// Creates a new goal which works with <see cref="Heuristics" />.
         /// </summary>
         /// <param name="tactic">The tactic used to approach this goal.</param>
@@ -106,8 +101,7 @@ namespace Aplib.Core.Desire.Goals
         /// Gets the <see cref="Heuristics" /> of the current state of the game.
         /// </summary>
         /// <remarks>If no heuristics have been calculated yet, they will be calculated first.</remarks>
-        public virtual Heuristics CurrentHeuristics(TBeliefSet beliefSet)
-            => _currentHeuristics ??= _heuristicFunction.Invoke(beliefSet);
+        public virtual Heuristics CurrentHeuristics(TBeliefSet beliefSet) => _heuristicFunction.Invoke(beliefSet);
 
         /// <summary>
         /// Tests whether the goal has been achieved, bases on the <see cref="_heuristicFunction" /> and the

--- a/Aplib.Core/Desire/Goals/IGoal.cs
+++ b/Aplib.Core/Desire/Goals/IGoal.cs
@@ -20,11 +20,11 @@ namespace Aplib.Core.Desire.Goals
         /// Gets the <see cref="Heuristics" /> of the current state of the game.
         /// </summary>
         /// <remarks>If no heuristics have been calculated yet, they will be calculated first.</remarks>
-        Heuristics CurrentHeuristics(TBeliefSet beliefSet);
+        Heuristics DetermineCurrentHeuristics(TBeliefSet beliefSet);
 
         /// <summary>
         /// Tests whether the goal has been achieved, based on the <see cref="Goal{TBeliefSet}._heuristicFunction" /> and the
-        /// <see cref="Goal{TBeliefSet}.CurrentHeuristics" />. When the distance of the heuristics is smaller than <see cref="Goal{TBeliefSet}._epsilon" />
+        /// <see cref="Goal{TBeliefSet}.DetermineCurrentHeuristics" />. When the distance of the heuristics is smaller than <see cref="Goal{TBeliefSet}._epsilon" />
         /// , the goal is considered to be completed.
         /// </summary>
         /// <returns>An enum representing whether the goal is complete and if so, with what result.</returns>

--- a/Aplib.Tests/Desire/GoalTests.cs
+++ b/Aplib.Tests/Desire/GoalTests.cs
@@ -121,13 +121,14 @@ public class GoalTests
     public void Goal_WhereHeuristicsChange_UsesUpdatedHeuristics()
     {
         // Arrange
+        IBeliefSet beliefSetMock = Mock.Of<IBeliefSet>();
         bool shouldSucceed = false;
         Goal<IBeliefSet> goal = new TestGoalBuilder().WithHeuristicFunction(_ => shouldSucceed).Build();
 
         // Act
-        CompletionStatus stateBefore = goal.GetStatus(It.IsAny<IBeliefSet>());
+        CompletionStatus stateBefore = goal.GetStatus(beliefSetMock);
         shouldSucceed = true; // Make heuristic function return a different value on next invoke
-        CompletionStatus stateAfter = goal.GetStatus(It.IsAny<IBeliefSet>());
+        CompletionStatus stateAfter = goal.GetStatus(beliefSetMock);
 
         // Assert
         stateBefore.Should().Be(CompletionStatus.Unfinished);

--- a/Aplib.Tests/Desire/GoalTests.cs
+++ b/Aplib.Tests/Desire/GoalTests.cs
@@ -2,7 +2,7 @@ using Aplib.Core.Belief;
 using Aplib.Core.Desire.Goals;
 using Aplib.Core.Intent.Actions;
 using Aplib.Core.Intent.Tactics;
-using Aplib.Tests.Tools;
+using Aplib.Core.Tests.Tools;
 using FluentAssertions;
 using Moq;
 
@@ -110,6 +110,28 @@ public class GoalTests
 
         // Assert
         beliefSetMock.Verify(beliefSetMock => beliefSetMock.UpdateBeliefs(), Times.Never);
+    }
+
+    /// <summary>
+    /// Given a valid goal with heuristics
+    /// when the goal's heuristic function's result will be different in the next frame
+    /// the most recent heuristics are used
+    /// </summary>
+    [Fact]
+    public void Goal_WhereHeuristicsChange_UsesUpdatedHeuristics()
+    {
+        // Arrange
+        bool shouldSucceed = false;
+        Goal<IBeliefSet> goal = new TestGoalBuilder().WithHeuristicFunction(_ => shouldSucceed).Build();
+
+        // Act
+        CompletionStatus stateBefore = goal.GetStatus(It.IsAny<IBeliefSet>());
+        shouldSucceed = true; // Make heuristic function return a different value on next invoke
+        CompletionStatus stateAfter = goal.GetStatus(It.IsAny<IBeliefSet>());
+
+        // Assert
+        stateBefore.Should().Be(CompletionStatus.Unfinished);
+        stateAfter.Should().Be(CompletionStatus.Success);
     }
 
     /// <summary>

--- a/Aplib.Tests/Tools/TestGoalBuilder.cs
+++ b/Aplib.Tests/Tools/TestGoalBuilder.cs
@@ -1,10 +1,9 @@
-using Aplib.Core;
 using Aplib.Core.Belief;
 using Aplib.Core.Desire.Goals;
 using Aplib.Core.Intent.Tactics;
 using Moq;
 
-namespace Aplib.Tests.Tools;
+namespace Aplib.Core.Tests.Tools;
 
 internal sealed class TestGoalBuilder
 {


### PR DESCRIPTION
## Description

The `_currentHeuristics` field of a Goal is never updated, as the property only set its backing field when the backing field is `null`, which it only is in the first frame.

This PR removes the backing field completely, and instead recalculates the heuristics every time the property is invoked.

## Testability

See the new test I included. You can test this fix by confirming that a goal can be considered completed or failed, even after multiple frames of being unfinished.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch