### PR TITLE
 fix: pre-commit hook error

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@
 # Find all c# related staged files, before doing anything
 FILES_TO_BE_FORMATTED=$(git diff --staged --name-only | grep -E '\.(cs|csproj|sln)$' || echo '')
 
-if [ -z $FILES_TO_BE_FORMATTED ]; then
+if [ -z "$FILES_TO_BE_FORMATTED" ]; then
 	echo "No .NET files to format, skipping dotnet format..."
 	exit 0
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,8 @@
 # Boilerplate husky
 . "$(dirname "$0")/_/husky.sh"
 
-# Find all c# related staged files, before doing anything
-FILES_TO_BE_FORMATTED=$(git diff --staged --name-only | grep -E '\.(cs|csproj|sln)$' || echo '')
+# Find all c# related staged files still existing on the disk, before doing anything
+FILES_TO_BE_FORMATTED=$(git diff --staged --name-only --diff-filter=du | grep -E '\.(cs|csproj|sln)$' || echo '')
 
 if [ -z "$FILES_TO_BE_FORMATTED" ]; then
 	echo "No .NET files to format, skipping dotnet format..."


### PR DESCRIPTION
## Description

There is a minor bug in the pre-commit script, where if more than one file is present in `FILES_TO_BE_FORMATTED`, the `-z` operator is applied to two arguments, which fails.

Instead, the `-z` operator should be tested against a string.

Basically, I got the following output when committing:

```bash
.husky/pre-commit: line 9: [: aplib.net-demo/Assets/Scripts/Tiles/Direction.cs: binary operator expected
Files to be formatted:
 - aplib.net-demo/Assets/Scripts/Tiles/Direction.cs
 - aplib.net-demo/Assets/Scripts/Tiles/Tile.cs

  The dotnet runtime version is '8.0.2'.
  The dotnet CLI version is '8.0.102'
[...]
```

## Testability

Frick around and find out!

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch