### PR TITLE
fix: add skip duplicate flag to dotnet nuget push

### DIFF
--- a/.github/workflows/test-build-release.yml
+++ b/.github/workflows/test-build-release.yml
@@ -198,4 +198,4 @@ jobs:
           name: nuget-package
           path: bin
       - name: Upload NuGet Package to NuGet.org
-        run: dotnet nuget push bin/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push bin/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Description

This PR adds a skip duplicate flag to dotnet nuget push so it doesn't fail if no new version was generated, such as with chore commits on main.

## Testability

Watch the pipeline.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch