### PR TITLE
feat: Add Observation property to Belief

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -446,3 +446,6 @@ fabric.properties
 
 *.iml
 modules.xml
+
+### Ignore all .idea files
+**/.idea/

--- a/Aplib.Core/Belief/Belief.cs
+++ b/Aplib.Core/Belief/Belief.cs
@@ -4,7 +4,7 @@ namespace Aplib.Core.Belief
 {
     /// <summary>
     /// The <see cref="Belief{TReference, TObservation}"/> class represents the agent's belief of a single object.
-    /// Some <i>object reference</i> is used to generate/update an <i>observation</i> 
+    /// Some <i>object reference</i> is used to generate/update an <i>observation</i>
     /// (i.e., some piece of information of the game state as perceived by an agent).
     /// </summary>
     /// <remarks>
@@ -33,7 +33,11 @@ namespace Aplib.Core.Belief
         /// <summary>
         /// The observation represented by the belief (i.e., some piece of information of the game state as perceived by an agent).
         /// </summary>
-        private TObservation _observation;
+        public TObservation Observation
+        {
+            get;
+            protected set;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Belief{TReference, TObservation}"/> class with an object reference,
@@ -45,7 +49,7 @@ namespace Aplib.Core.Belief
         {
             _reference = reference;
             _getObservationFromReference = getObservationFromReference;
-            _observation = _getObservationFromReference(_reference);
+            Observation = _getObservationFromReference(_reference);
         }
 
         /// <summary>
@@ -56,18 +60,20 @@ namespace Aplib.Core.Belief
         /// <param name="reference">The object reference used to generate/update the observation.</param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
-        public Belief(TReference reference, Func<TReference, TObservation> getObservationFromReference, Func<bool> shouldUpdate)
+        public Belief(TReference reference,
+            Func<TReference, TObservation> getObservationFromReference,
+            Func<bool> shouldUpdate)
             : this(reference, getObservationFromReference)
         {
             _shouldUpdate = shouldUpdate;
         }
 
         /// <summary>
-        /// Implicit conversion operator to allow a <see cref="Belief{TReference, TObservation}"/> object 
+        /// Implicit conversion operator to allow a <see cref="Belief{TReference, TObservation}"/> object
         /// to be used where a <typeparamref name="TObservation"/> is expected.
         /// </summary>
         /// <param name="belief">The <see cref="Belief{TReference, TObservation}"/> object to convert.</param>
-        public static implicit operator TObservation(Belief<TReference, TObservation> belief) => belief._observation;
+        public static implicit operator TObservation(Belief<TReference, TObservation> belief) => belief.Observation;
 
         /// <summary>
         /// Generates/updates the observation if the shouldUpdate condition is satisfied.
@@ -75,7 +81,7 @@ namespace Aplib.Core.Belief
         /// </summary>
         public virtual void UpdateBelief()
         {
-            if (_shouldUpdate()) _observation = _getObservationFromReference(_reference);
+            if (_shouldUpdate()) Observation = _getObservationFromReference(_reference);
         }
     }
 }

--- a/Aplib.Tests/Aplib.Core.Tests.csproj
+++ b/Aplib.Tests/Aplib.Core.Tests.csproj
@@ -35,8 +35,4 @@
         <ProjectReference Include="..\Aplib.Core\Aplib.Core.csproj" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Stubs\" />
-    </ItemGroup>
-
 </Project>

--- a/Aplib.Tests/Belief/BeliefTests.cs
+++ b/Aplib.Tests/Belief/BeliefTests.cs
@@ -58,6 +58,7 @@ public class BeliefTests
 
         // Assert
         Assert.Equal(list.Count, belief);
+        Assert.Equal(list.Count, belief.Observation);
     }
 
     /// <summary>
@@ -78,6 +79,7 @@ public class BeliefTests
 
         // Assert
         Assert.NotEqual(list.Count, belief);
+        Assert.NotEqual(list.Count, belief.Observation);
     }
 
     /// <summary>
@@ -98,5 +100,6 @@ public class BeliefTests
 
         // Assert
         Assert.NotEqual(def, belief);
+        Assert.NotEqual(def, belief.Observation);
     }
 }


### PR DESCRIPTION
## Description

This PR proposes to add the observation property as described in APLIB-102. I have chosen not to add it to `IBelief` as this belief does not contain a generic type indicating what type the observation property must be.

## Testability

All changes are tested using Unit Tests.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch

## Acceptance Criteria
- The IBelief and all beliefs in Aplib.Core must correctly implement the observation property (per Liskov substitution)
- The observation must give back the object which the stored Observation type.