### PR TITLE
feat: add ListBelief

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -447,5 +447,5 @@ fabric.properties
 *.iml
 modules.xml
 
-### Ignore all .idea files
+# Rider files
 **/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -447,5 +447,5 @@ fabric.properties
 *.iml
 modules.xml
 
-# Rider files
+# JetBrains IDE files
 **/.idea/

--- a/Aplib.Core/Belief/Belief.cs
+++ b/Aplib.Core/Belief/Belief.cs
@@ -47,7 +47,9 @@ namespace Aplib.Core.Belief
         /// interface.
         /// </param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="reference"/> is not a reference type.
+        /// </exception>
         public Belief(TReference reference, Func<TReference, TObservation> getObservationFromReference)
         {
             Type referenceType = reference.GetType();
@@ -70,7 +72,9 @@ namespace Aplib.Core.Belief
         /// </param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="reference"/> is not a reference type.
+        /// </exception>
         public Belief(TReference reference,
             Func<TReference, TObservation> getObservationFromReference,
             Func<bool> shouldUpdate)

--- a/Aplib.Core/Belief/Belief.cs
+++ b/Aplib.Core/Belief/Belief.cs
@@ -47,8 +47,13 @@ namespace Aplib.Core.Belief
         /// interface.
         /// </param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
         public Belief(TReference reference, Func<TReference, TObservation> getObservationFromReference)
         {
+            Type referenceType = reference.GetType();
+            if (referenceType.IsValueType)
+                throw new ArgumentException($"{referenceType.FullName} is not a reference type.", nameof(reference));
+
             _reference = reference;
             _getObservationFromReference = getObservationFromReference;
             Observation = _getObservationFromReference(_reference);
@@ -65,6 +70,7 @@ namespace Aplib.Core.Belief
         /// </param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
         public Belief(TReference reference,
             Func<TReference, TObservation> getObservationFromReference,
             Func<bool> shouldUpdate)

--- a/Aplib.Core/Belief/Belief.cs
+++ b/Aplib.Core/Belief/Belief.cs
@@ -10,9 +10,12 @@ namespace Aplib.Core.Belief
     /// <remarks>
     /// It supports implicit conversion to <typeparamref name="TObservation"/>.
     /// </remarks>
-    /// <typeparam name="TReference">The type of the object reference used to generate/update the observation.</typeparam>
+    /// <typeparam name="TReference">
+    /// The type of the object reference used to generate/update the observation. This <i>must</i> be a reference type,
+    /// be aware that this is not enforced by C# if <typeparamref name="TReference"/> is an interface.
+    /// </typeparam>
     /// <typeparam name="TObservation">The type of the observation that the belief represents.</typeparam>
-    public class Belief<TReference, TObservation> : IBelief
+    public class Belief<TReference, TObservation> : IBelief where TReference : class
     {
         /// <summary>
         /// The object reference used to generate/update the observation.
@@ -38,7 +41,11 @@ namespace Aplib.Core.Belief
         /// Initializes a new instance of the <see cref="Belief{TReference, TObservation}"/> class with an object reference,
         /// and a function to generate/update the observation using the object reference.
         /// </summary>
-        /// <param name="reference">A function that takes an object reference and generates/updates an observation.</param>
+        /// <param name="reference">
+        /// A function that takes an object reference and generates/updates an observation. This <i>must</i> be a
+        /// reference type, be aware that this is not enforced by C# if <typeparamref name="TReference"/> is an
+        /// interface.
+        /// </param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
         public Belief(TReference reference, Func<TReference, TObservation> getObservationFromReference)
         {
@@ -52,7 +59,10 @@ namespace Aplib.Core.Belief
         /// a function to generate/update the observation using the object reference,
         /// and a condition on when the observation should be updated.
         /// </summary>
-        /// <param name="reference">The object reference used to generate/update the observation.</param>
+        /// <param name="reference">
+        /// The object reference used to generate/update the observation. This <i>must</i> be a reference type, be aware
+        /// that this is not enforced by C# if <typeparamref name="TReference"/> is an interface.
+        /// </param>
         /// <param name="getObservationFromReference">A function that takes an object reference and generates/updates an observation.</param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
         public Belief(TReference reference,

--- a/Aplib.Core/Belief/ListBelief.cs
+++ b/Aplib.Core/Belief/ListBelief.cs
@@ -32,6 +32,7 @@ namespace Aplib.Core.Belief
         /// <param name="getObservationFromReference">
         /// A function that takes an object reference and generates an observation.
         /// </param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="references"/> is not a reference type.</exception>
         public ListBelief
         (
             IEnumerable<TReference> references,
@@ -53,6 +54,7 @@ namespace Aplib.Core.Belief
         /// A function that takes an object reference and generates an observation.
         /// </param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="references"/> is not a reference type.</exception>
         public ListBelief
         (
             IEnumerable<TReference> references,

--- a/Aplib.Core/Belief/ListBelief.cs
+++ b/Aplib.Core/Belief/ListBelief.cs
@@ -32,7 +32,9 @@ namespace Aplib.Core.Belief
         /// <param name="getObservationFromReference">
         /// A function that takes an object reference and generates an observation.
         /// </param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="references"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="references"/> is not a reference type.
+        /// </exception>
         public ListBelief
         (
             IEnumerable<TReference> references,
@@ -54,7 +56,9 @@ namespace Aplib.Core.Belief
         /// A function that takes an object reference and generates an observation.
         /// </param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="references"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="references"/> is not a reference type.
+        /// </exception>
         public ListBelief
         (
             IEnumerable<TReference> references,

--- a/Aplib.Core/Belief/ListBelief.cs
+++ b/Aplib.Core/Belief/ListBelief.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Aplib.Core.Belief
+{
+    /// <summary>
+    /// A convenience variant of <see cref="Belief{TReference,TObservation}"/> to track multiple references in one
+    /// belief. Both the collection storing the references and the references themselves can be changed after the
+    /// <see cref="ListBelief{TReference,TObservation}"/> has been created.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="ListBelief{TReference,TObservation}"/> can be implicitly converted to a
+    /// <see cref="List{TObservation}"/>, which will have the same size as the reference collection the last time that
+    /// <see cref="Belief{TReference,TObservation}.UpdateBelief"/> was called, and contain the observation results for
+    /// each element in the collection.
+    /// </remarks>
+    /// <typeparam name="TReference">
+    /// The type of the object references used to generate/update the observation.
+    /// </typeparam>
+    /// <typeparam name="TObservation">The type of the observation that the belief represents.</typeparam>
+    public class ListBelief<TReference, TObservation> : Belief<IEnumerable<TReference>, List<TObservation>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListBelief{TReference,TObservation}"/> class from an object
+        /// reference collection, and a function to generate an observation from an object reference.
+        /// </summary>
+        /// <param name="references">
+        /// The collection of reference objects. The underlying type implementing <see cref="IEnumerable{TReference}"/>
+        /// <i>must</i> be a reference type, note that this is not enforced by C#.
+        /// </param>
+        /// <param name="getObservationFromReference">
+        /// A function that takes an object reference and generates an observation.
+        /// </param>
+        public ListBelief
+        (
+            IEnumerable<TReference> references,
+            Func<TReference, TObservation> getObservationFromReference
+        )
+            : base(references, refer => refer.Select(getObservationFromReference).ToList())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ListBelief{TReference,TObservation}"/> class from an object
+        /// reference collection, a function to generate an observation from an object reference, and an update guard.
+        /// </summary>
+        /// <param name="references">
+        /// The collection of reference objects. The underlying type implementing <see cref="IEnumerable{TReference}"/>
+        /// <i>must</i> be a reference type, note that this is not enforced by C#.
+        /// </param>
+        /// <param name="getObservationFromReference">
+        /// A function that takes an object reference and generates an observation.
+        /// </param>
+        /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
+        public ListBelief
+        (
+            IEnumerable<TReference> references,
+            Func<TReference, TObservation> getObservationFromReference,
+            Func<bool> shouldUpdate
+        )
+            : base(references, refer => refer.Select(getObservationFromReference).ToList(), shouldUpdate)
+        {
+        }
+    }
+}

--- a/Aplib.Core/Belief/ListBelief.cs
+++ b/Aplib.Core/Belief/ListBelief.cs
@@ -5,28 +5,28 @@ using System.Linq;
 namespace Aplib.Core.Belief
 {
     /// <summary>
-    /// A convenience variant of <see cref="Belief{TReference,TObservation}"/> to track multiple references in one
+    /// A convenience variant of <see cref="Belief{TReference,TObservation}" /> to track multiple references in one
     /// belief. Both the collection storing the references and the references themselves can be changed after the
-    /// <see cref="ListBelief{TReference,TObservation}"/> has been created.
+    /// <see cref="ListBelief{TReference,TObservation}" /> has been created.
     /// </summary>
     /// <remarks>
-    /// A <see cref="ListBelief{TReference,TObservation}"/> can be implicitly converted to a
-    /// <see cref="List{TObservation}"/>, which will have the same size as the reference collection the last time that
-    /// <see cref="Belief{TReference,TObservation}.UpdateBelief"/> was called, and contain the observation results for
+    /// A <see cref="ListBelief{TReference,TObservation}" /> can be implicitly converted to a
+    /// <see cref="List{TObservation}" />, which will have the same size as the reference collection the last time that
+    /// <see cref="Belief{TReference,TObservation}.UpdateBelief" /> was called, and contain the observation results for
     /// each element in the collection.
     /// </remarks>
     /// <typeparam name="TReference">
     /// The type of the object references used to generate/update the observation.
     /// </typeparam>
-    /// <typeparam name="TObservation">The type of the observation that the belief represents.</typeparam>
+    /// <typeparam name="TObservation">The type of the observations that the belief represents.</typeparam>
     public class ListBelief<TReference, TObservation> : Belief<IEnumerable<TReference>, List<TObservation>>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ListBelief{TReference,TObservation}"/> class from an object
+        /// Initializes a new instance of the <see cref="ListBelief{TReference,TObservation}" /> class from an object
         /// reference collection, and a function to generate an observation from an object reference.
         /// </summary>
         /// <param name="references">
-        /// The collection of reference objects. The underlying type implementing <see cref="IEnumerable{TReference}"/>
+        /// The collection of reference objects. The underlying type implementing <see cref="IEnumerable{TReference}" />
         /// <i>must</i> be a reference type, note that this is not enforced by C#.
         /// </param>
         /// <param name="getObservationFromReference">
@@ -42,11 +42,11 @@ namespace Aplib.Core.Belief
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ListBelief{TReference,TObservation}"/> class from an object
+        /// Initializes a new instance of the <see cref="ListBelief{TReference,TObservation}" /> class from an object
         /// reference collection, a function to generate an observation from an object reference, and an update guard.
         /// </summary>
         /// <param name="references">
-        /// The collection of reference objects. The underlying type implementing <see cref="IEnumerable{TReference}"/>
+        /// The collection of reference objects. The underlying type implementing <see cref="IEnumerable{TReference}" />
         /// <i>must</i> be a reference type, note that this is not enforced by C#.
         /// </param>
         /// <param name="getObservationFromReference">

--- a/Aplib.Core/Belief/MemoryBelief.cs
+++ b/Aplib.Core/Belief/MemoryBelief.cs
@@ -12,9 +12,12 @@ namespace Aplib.Core.Belief
     /// <remarks>
     /// It supports implicit conversion to <typeparamref name="TObservation"/>.
     /// </remarks>
-    /// <typeparam name="TReference">The type of the reference used to generate/update the observation.</typeparam>
+    /// <typeparam name="TReference">
+    /// The type of the reference used to generate/update the observation. This <i>must</i> be a reference type, be aware that
+    /// this is not enforced by C# if <typeparamref name="TReference"/> is an interface.
+    /// </typeparam>
     /// <typeparam name="TObservation">The type of the observation the belief represents.</typeparam>
-    public class MemoryBelief<TReference, TObservation> : Belief<TReference, TObservation>
+    public class MemoryBelief<TReference, TObservation> : Belief<TReference, TObservation> where TReference : class
     {
         /// <summary>
         /// A "memorized" resource, from the last time the belief was updated.
@@ -26,7 +29,10 @@ namespace Aplib.Core.Belief
         /// and a function to generate/update the observation using the object reference.
         /// Also initializes the memory array with a specified number of slots.
         /// </summary>
-        /// <param name="reference">The reference used to generate/update the observation.</param>
+        /// <param name="reference">
+        /// The reference used to generate/update the observation. This <i>must</i> be a reference type, be aware that
+        /// this is not enforced by C# if <typeparamref name="TReference"/> is an interface.
+        /// </param>
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
         public MemoryBelief
@@ -46,7 +52,10 @@ namespace Aplib.Core.Belief
         /// and a condition on when the observation should be updated.
         /// Also initializes the memory array with a specified number of slots.
         /// </summary>
-        /// <param name="reference">The reference used to generate/update the observation.</param>
+        /// <param name="reference">
+        /// The reference used to generate/update the observation. This <i>must</i> be a reference type, be aware that
+        /// this is not enforced by C# if <typeparamref name="TReference"/> is an interface.
+        /// </param>
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
         /// <param name="shouldUpdate">A function that sets a condition on when the observation should be updated.</param>

--- a/Aplib.Core/Belief/MemoryBelief.cs
+++ b/Aplib.Core/Belief/MemoryBelief.cs
@@ -35,6 +35,7 @@ namespace Aplib.Core.Belief
         /// </param>
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
         public MemoryBelief
         (
             TReference reference,
@@ -59,6 +60,7 @@ namespace Aplib.Core.Belief
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
         /// <param name="shouldUpdate">A function that sets a condition on when the observation should be updated.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
         public MemoryBelief
         (
             TReference reference,

--- a/Aplib.Core/Belief/MemoryBelief.cs
+++ b/Aplib.Core/Belief/MemoryBelief.cs
@@ -35,7 +35,9 @@ namespace Aplib.Core.Belief
         /// </param>
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="reference"/> is not a reference type.
+        /// </exception>
         public MemoryBelief
         (
             TReference reference,
@@ -60,7 +62,9 @@ namespace Aplib.Core.Belief
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
         /// <param name="shouldUpdate">A function that sets a condition on when the observation should be updated.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="reference"/> is not a reference type.
+        /// </exception>
         public MemoryBelief
         (
             TReference reference,

--- a/Aplib.Core/Belief/SampledMemoryBelief.cs
+++ b/Aplib.Core/Belief/SampledMemoryBelief.cs
@@ -61,7 +61,9 @@ namespace Aplib.Core.Belief
         /// </param>
         /// <param name="updateMode">Specifies how this sampled memory belief should be updated.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="reference"/> is not a reference type.
+        /// </exception>
         public SampledMemoryBelief
         (
             TReference reference,
@@ -94,7 +96,9 @@ namespace Aplib.Core.Belief
         /// <param name="updateMode">Specifies how this sampled memory belief should be updated.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
         /// <param name="shouldUpdate">A function that sets a condition on when the observation should be updated.</param>
-        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="reference"/> is not a reference type.
+        /// </exception>
         public SampledMemoryBelief
         (
             TReference reference,

--- a/Aplib.Core/Belief/SampledMemoryBelief.cs
+++ b/Aplib.Core/Belief/SampledMemoryBelief.cs
@@ -15,9 +15,13 @@ namespace Aplib.Core.Belief
     /// <remarks>
     /// It supports implicit conversion to <typeparamref name="TObservation"/>.
     /// </remarks>
-    /// <typeparam name="TReference">The type of the reference used to generate/update the observation.</typeparam>
+    /// <typeparam name="TReference">
+    /// The type of the reference used to generate/update the observation. This <i>must</i> be a reference type, be
+    /// aware that this is not enforced by C# if <typeparamref name="TReference"/> is an interface.
+    /// </typeparam>
     /// <typeparam name="TObservation">The type of the observation the belief represents.</typeparam>
     public class SampledMemoryBelief<TReference, TObservation> : MemoryBelief<TReference, TObservation>
+        where TReference : class
     {
         /// <summary>
         /// The sample interval of the memory (inverse of the sample rate).
@@ -47,7 +51,9 @@ namespace Aplib.Core.Belief
         /// This belief also stores a limited amount of previous observation samples in memory.
         /// Optionally, the belief can always store the most recent observation, regardless of the sample rate.
         /// </summary>
-        /// <param name="reference">The reference used to generate/update the observation.</param>
+        /// <param name="reference">
+        /// The reference used to generate/update the observation. This <i>must</i> be a reference type.
+        /// </param>
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="sampleInterval">
         /// The sample interval of the memory.
@@ -55,6 +61,7 @@ namespace Aplib.Core.Belief
         /// </param>
         /// <param name="updateMode">Specifies how this sampled memory belief should be updated.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
         public SampledMemoryBelief
         (
             TReference reference,
@@ -76,7 +83,9 @@ namespace Aplib.Core.Belief
         /// This belief also stores a limited amount of previous observation samples in memory.
         /// Optionally, the belief can always store the most recent observation, regardless of the sample rate.
         /// </summary>
-        /// <param name="reference">The reference used to generate/update the observation.</param>
+        /// <param name="reference">
+        /// The reference used to generate/update the observation. This <i>must</i> be a reference type.
+        /// </param>
         /// <param name="getObservationFromReference">A function that takes a reference and generates/updates a observation.</param>
         /// <param name="sampleInterval">
         /// The sample rate of the memory.
@@ -85,6 +94,7 @@ namespace Aplib.Core.Belief
         /// <param name="updateMode">Specifies how this sampled memory belief should be updated.</param>
         /// <param name="framesToRemember">The number of frames to remember back.</param>
         /// <param name="shouldUpdate">A function that sets a condition on when the observation should be updated.</param>
+        /// <exception cref="ArgumentException">Thrown when <see cref="reference"/> is not a reference type.</exception>
         public SampledMemoryBelief
         (
             TReference reference,

--- a/Aplib.Tests/Belief/BeliefTests.cs
+++ b/Aplib.Tests/Belief/BeliefTests.cs
@@ -25,12 +25,7 @@ public class BeliefTests
         // Observation: Get the first letter.
         Belief<string, char> belief = new(def, reference => reference[0]);
 
-        // Act
-        char observation = belief;
-
-        // Assert
-        Assert.Equal('d', observation);
-        Assert.Equal('d', belief.Observation);
+        // Act, Assert
         Assert.Equal(belief.Observation, belief);
     }
 

--- a/Aplib.Tests/Belief/BeliefTests.cs
+++ b/Aplib.Tests/Belief/BeliefTests.cs
@@ -34,14 +34,15 @@ public class BeliefTests
         // Arrange
         // ReSharper disable once ConvertToConstant.Local
         string def = "def";
-        Belief<string, string> belief = new(def, reference => reference);
+        // Observation: Get the first letter.
+        Belief<string, char> belief = new(def, reference => reference[0]);
 
         // Act
-        string observation = belief;
+        char observation = belief;
 
         // Assert
-        Assert.Equal(def, observation);
-        Assert.Equal(def, belief.Observation);
+        Assert.Equal('d', observation);
+        Assert.Equal('d', belief.Observation);
         Assert.Equal(belief.Observation, belief);
     }
 
@@ -104,7 +105,6 @@ public class BeliefTests
         belief.UpdateBelief();
 
         // Assert
-        Assert.NotEqual(def, belief);
         Assert.NotEqual(def, belief.Observation);
     }
 

--- a/Aplib.Tests/Belief/BeliefTests.cs
+++ b/Aplib.Tests/Belief/BeliefTests.cs
@@ -30,6 +30,7 @@ public class BeliefTests
     public void Belief_AssignedToObservationType_IsCorrectlyImplicitlyConvertedToObservationType()
     {
         // Arrange
+        // ReSharper disable once ConvertToConstant.Local
         string def = "def";
         Belief<string, string> belief = new(def, reference => reference);
 
@@ -38,6 +39,8 @@ public class BeliefTests
 
         // Assert
         Assert.Equal(def, observation);
+        Assert.Equal(def, belief.Observation);
+        Assert.Equal(belief.Observation, belief);
     }
 
     /// <summary>
@@ -101,5 +104,24 @@ public class BeliefTests
         // Assert
         Assert.NotEqual(def, belief);
         Assert.NotEqual(def, belief.Observation);
+    }
+
+    /// <summary>
+    /// Given a reference,
+    /// When a new Belief is constructed,
+    /// Then the observation is also initialized.
+    /// </summary>
+    [Fact]
+    public void Belief_DuringConstruction_UpdatesTheObservation()
+    {
+        // Arrange
+        // ReSharper disable once ConvertToConstant.Local
+        string def = "def";
+
+        // Act
+        Belief<string, string> belief = new(def, str => str);
+
+        // Assert
+        Assert.Equal(def, belief.Observation);
     }
 }

--- a/Aplib.Tests/Belief/BeliefTests.cs
+++ b/Aplib.Tests/Belief/BeliefTests.cs
@@ -12,18 +12,6 @@ namespace Aplib.Core.Tests.Belief;
 public class BeliefTests
 {
     /// <summary>
-    /// A constant 'true' method for testing.
-    /// </summary>
-    /// <returns>True.</returns>
-    private static bool AlwaysUpdate() => true;
-
-    /// <summary>
-    /// A constant 'false' method for testing.
-    /// </summary>
-    /// <returns>False.</returns>
-    private static bool NeverUpdate() => false;
-
-    /// <summary>
     /// Given a Belief instance,
     /// When it is assigned to a variable of its observation type,
     /// Then it is implicitly converted to its observation type.
@@ -56,7 +44,7 @@ public class BeliefTests
     {
         // Arrange
         List<int> list = [];
-        Belief<List<int>, int> belief = new(list, reference => reference.Count, AlwaysUpdate);
+        Belief<List<int>, int> belief = new(list, reference => reference.Count, () => true);
 
         // Act
         list.Add(69);
@@ -77,7 +65,7 @@ public class BeliefTests
     {
         // Arrange
         List<int> list = [];
-        Belief<List<int>, int> belief = new(list, reference => reference.Count, NeverUpdate);
+        Belief<List<int>, int> belief = new(list, reference => reference.Count, () => false);
 
         // Act
         list.Add(420);
@@ -98,7 +86,7 @@ public class BeliefTests
     {
         // Arrange
         string def = "def";
-        Belief<string, string> belief = new(def, reference => reference, AlwaysUpdate);
+        Belief<string, string> belief = new(def, reference => reference, () => true);
 
         // Act
         def = "abc";

--- a/Aplib.Tests/Belief/ListBeliefTests.cs
+++ b/Aplib.Tests/Belief/ListBeliefTests.cs
@@ -37,7 +37,7 @@ public class ListBeliefTests
     }
 
     /// <summary>
-    /// Given a ListBelief with an shouldUpdate condition that is not satisfied,
+    /// Given a ListBelief with a shouldUpdate condition that is not satisfied,
     /// When UpdateBelief is called,
     /// Then the observation is not updated.
     /// </summary>
@@ -72,10 +72,9 @@ public class ListBeliefTests
 
         // Act
         ListBelief<byte, byte> belief = new(stack, b => b);
-        belief.UpdateBelief();
 
         // Assert
-        Assert.Equal(new List<byte>(), belief);
+        Assert.Empty(belief.Observation);
     }
 
     // [Fact]

--- a/Aplib.Tests/Belief/ListBeliefTests.cs
+++ b/Aplib.Tests/Belief/ListBeliefTests.cs
@@ -1,0 +1,112 @@
+using Aplib.Core.Belief;
+using System.Collections.Generic;
+
+namespace Aplib.Core.Tests.Belief;
+
+/// <summary>
+/// Unit tests for <see cref="ListBelief{TReference,TObservation}" />.
+/// </summary>
+public class ListBeliefTests
+{
+    /// <summary>
+    /// A constant 'false' method for testing.
+    /// </summary>
+    /// <returns><c>false</c>.</returns>
+    private static bool NeverUpdate() => false;
+
+    /// <summary>
+    /// Given a ListBelief without an explicit shouldUpdate parameter,
+    /// When UpdateBelief is called,
+    /// Then the observation is updated.
+    /// </summary>
+    [Fact]
+    public void ListBelief_WithoutShouldUpdate_UpdatesObservation()
+    {
+        // Arrange
+        int[] numbers = [1, 1, 2, 3, 5, 8];
+        // Observation: Is the number even?
+        ListBelief<int, bool> belief = new(numbers, i => i % 2 == 0);
+
+        // Act
+        numbers[0] = 0;
+        belief.UpdateBelief();
+
+        // Assert
+        List<bool> expected = [true, false, true, false, false, true];
+        Assert.Equal(expected, belief);
+    }
+
+    /// <summary>
+    /// Given a ListBelief with an shouldUpdate condition that is not satisfied,
+    /// When UpdateBelief is called,
+    /// Then the observation is not updated.
+    /// </summary>
+    [Fact]
+    public void ListBelief_ShouldUpdateConditionIsNotSatisfied_DoesNotUpdateObservation()
+    {
+        // Arrange
+        List<string> strings = ["foo", "bar"];
+        // Observation: What is the last character?
+        ListBelief<string, char> belief = new(strings, str => str[^1], NeverUpdate);
+
+        // Act
+        // Append 'x' to each string
+        for (int i = 0; i < strings.Count; i++) strings[i] += 'x';
+        belief.UpdateBelief();
+
+        // Assert
+        Assert.Equal(new List<char> { 'o', 'r' }, belief);
+    }
+
+    /// <summary>
+    /// Given an empty collection,
+    /// When a ListBelief is created from that collection,
+    /// Then the observation is also empty
+    /// </summary>
+    [Fact]
+    public void ListBelief_FromEmptyEnumerable_HasEmptyObservationList()
+    {
+        // Arrange
+        // ReSharper disable once CollectionNeverUpdated.Local
+        Stack<byte> stack = new();
+
+        // Act
+        ListBelief<byte, byte> belief = new(stack, b => b);
+        belief.UpdateBelief();
+
+        // Assert
+        Assert.Equal(new List<byte>(), belief);
+    }
+
+    // [Fact]
+    // public void Bug()
+    // {
+    //     // Arrange
+    //     MyEnumerable value = new(1);
+    //     // The bug is the fact that we can get around the constraint that `TReference` should be a reference type.
+    //     Belief<IEnumerable<int>, List<int>> belief = new(value, vs => vs.ToList());
+    //
+    //     // Act
+    //     value.Number = 2;
+    //     belief.UpdateBelief();
+    //
+    //     // Assert
+    //     Assert.Equal(new List<int> { 2, 2, 2 }, belief);
+    // }
+    //
+    // private struct MyEnumerable : IEnumerable<int>
+    // {
+    //     public int Number { get; set; }
+    //
+    //     private const int MAX = 3;
+    //
+    //     public MyEnumerable(int number) => Number = number;
+    //
+    //     public IEnumerator<int> GetEnumerator()
+    //     {
+    //         for (int i = 0; i < MAX; i++) yield return Number;
+    //     }
+    //
+    //     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    // }
+}

--- a/Aplib.Tests/Belief/ListBeliefTests.cs
+++ b/Aplib.Tests/Belief/ListBeliefTests.cs
@@ -9,12 +9,6 @@ namespace Aplib.Core.Tests.Belief;
 public class ListBeliefTests
 {
     /// <summary>
-    /// A constant 'false' method for testing.
-    /// </summary>
-    /// <returns><c>false</c>.</returns>
-    private static bool NeverUpdate() => false;
-
-    /// <summary>
     /// Given a ListBelief without an explicit shouldUpdate parameter,
     /// When UpdateBelief is called,
     /// Then the observation is updated.
@@ -47,7 +41,7 @@ public class ListBeliefTests
         // Arrange
         List<string> strings = ["foo", "bar"];
         // Observation: What is the last character?
-        ListBelief<string, char> belief = new(strings, str => str[^1], NeverUpdate);
+        ListBelief<string, char> belief = new(strings, str => str[^1], () => false);
 
         // Act
         // Append 'x' to each string

--- a/Aplib.Tests/Belief/ListBeliefTests.cs
+++ b/Aplib.Tests/Belief/ListBeliefTests.cs
@@ -76,36 +76,4 @@ public class ListBeliefTests
         // Assert
         Assert.Empty(belief.Observation);
     }
-
-    // [Fact]
-    // public void Bug()
-    // {
-    //     // Arrange
-    //     MyEnumerable value = new(1);
-    //     // The bug is the fact that we can get around the constraint that `TReference` should be a reference type.
-    //     Belief<IEnumerable<int>, List<int>> belief = new(value, vs => vs.ToList());
-    //
-    //     // Act
-    //     value.Number = 2;
-    //     belief.UpdateBelief();
-    //
-    //     // Assert
-    //     Assert.Equal(new List<int> { 2, 2, 2 }, belief);
-    // }
-    //
-    // private struct MyEnumerable : IEnumerable<int>
-    // {
-    //     public int Number { get; set; }
-    //
-    //     private const int MAX = 3;
-    //
-    //     public MyEnumerable(int number) => Number = number;
-    //
-    //     public IEnumerator<int> GetEnumerator()
-    //     {
-    //         for (int i = 0; i < MAX; i++) yield return Number;
-    //     }
-    //
-    //     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-    // }
 }


### PR DESCRIPTION
## Description

This PR adds a new subclass of `Belief` that is a convenience class for storing multiple entities in a single `Belief` instance.

## Acceptance Criteria

- ListBeblief should behave exactly like belief, but then with lists
- Emtpy lists should also be possible.
- Enumerations should also be possible

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch