### PR TITLE
feat: add combinators

### DIFF
--- a/Aplib.Core.Tests/CombinatorTests.cs
+++ b/Aplib.Core.Tests/CombinatorTests.cs
@@ -224,6 +224,48 @@ public class CombinatorTests
 
     [Theory]
     [MemberData(nameof(Metadatas))]
+    public void AnyOfTacticCombinator_WhenCalled_GivesExpectedTactic
+        (Metadata metadata, string? expectedName, string? expectedDescription)
+    {
+        // Arrange
+        Action<IBeliefSet> action1 = new(_ => { });
+        Action<IBeliefSet> action2 = new(_ => { });
+        // ReSharper disable once ConvertToLocalFunction
+        System.Func<IBeliefSet, bool> guard = _ => false;
+
+        // Act
+        AnyOfTactic<IBeliefSet> anyOfTactic =
+            AnyOf(metadata, guard, Primitive(action1, _ => true), Primitive(action2, _ => false));
+
+        IAction<IBeliefSet>? selectedAction = anyOfTactic.GetAction(It.IsAny<IBeliefSet>());
+
+        // Assert
+        CheckMetadata(expectedName, expectedDescription, anyOfTactic.Metadata);
+        selectedAction.Should().BeNull();
+    }
+
+    [Fact]
+    public void AnyOfTacticCombinator_WithoutMetadata_GivesExpectedTactic()
+    {
+        // Arrange
+        Action<IBeliefSet> action1 = new(_ => { });
+        Action<IBeliefSet> action2 = new(_ => { });
+        // ReSharper disable once ConvertToLocalFunction
+        System.Func<IBeliefSet, bool> guard = _ => false;
+
+        // Act
+        AnyOfTactic<IBeliefSet> anyOfTactic =
+            AnyOf(guard, Primitive(action1, _ => true), Primitive(action2, _ => false));
+
+        IAction<IBeliefSet>? selectedAction = anyOfTactic.GetAction(It.IsAny<IBeliefSet>());
+
+        // Assert
+        CheckDefaultMetadata(anyOfTactic.Metadata);
+        selectedAction.Should().BeNull();
+    }
+
+    [Theory]
+    [MemberData(nameof(Metadatas))]
     public void AnyOfTacticCombinator_WithoutGuard_GivesExpectedTactic
         (Metadata metadata, string? expectedName, string? expectedDescription)
     {
@@ -257,6 +299,48 @@ public class CombinatorTests
         // Assert
         CheckDefaultMetadata(anyOfTactic.Metadata);
         selectedAction.Should().Be(action1);
+    }
+
+    [Theory]
+    [MemberData(nameof(Metadatas))]
+    public void FirstOfTacticCombinator_WhenCalled_GivesExpectedTactic
+        (Metadata metadata, string? expectedName, string? expectedDescription)
+    {
+        // Arrange
+        Action<IBeliefSet> action1 = new(_ => { });
+        Action<IBeliefSet> action2 = new(_ => { });
+        // ReSharper disable once ConvertToLocalFunction
+        System.Func<IBeliefSet, bool> guard = _ => false;
+
+        // Act
+        FirstOfTactic<IBeliefSet> firstOfTactic =
+            FirstOf(metadata, guard, Primitive(action1, _ => false), Primitive(action2, _ => true));
+
+        IAction<IBeliefSet>? selectedAction = firstOfTactic.GetAction(It.IsAny<IBeliefSet>());
+
+        // Assert
+        CheckMetadata(expectedName, expectedDescription, firstOfTactic.Metadata);
+        selectedAction.Should().BeNull();
+    }
+
+    [Fact]
+    public void FirstOfTacticCombinator_WithoutMetadata_GivesExpectedTactic()
+    {
+        // Arrange
+        Action<IBeliefSet> action1 = new(_ => { });
+        Action<IBeliefSet> action2 = new(_ => { });
+        // ReSharper disable once ConvertToLocalFunction
+        System.Func<IBeliefSet, bool> guard = _ => false;
+
+        // Act
+        FirstOfTactic<IBeliefSet> firstOfTactic =
+            FirstOf(guard, Primitive(action1, _ => false), Primitive(action2, _ => true));
+
+        IAction<IBeliefSet>? selectedAction = firstOfTactic.GetAction(It.IsAny<IBeliefSet>());
+
+        // Assert
+        CheckDefaultMetadata(firstOfTactic.Metadata);
+        selectedAction.Should().BeNull();
     }
 
     [Theory]

--- a/Aplib.Core.Tests/CombinatorTests.cs
+++ b/Aplib.Core.Tests/CombinatorTests.cs
@@ -1,0 +1,213 @@
+using Aplib.Core.Belief.BeliefSets;
+using Aplib.Core.Desire.Goals;
+using Aplib.Core.Desire.GoalStructures;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using static Aplib.Core.Combinators;
+
+namespace Aplib.Core.Tests;
+
+public class CombinatorTests
+{
+    public static readonly IEnumerable<object?[]> Metadatas =
+    [
+        [new Metadata(System.Guid.Empty), null, null],
+        [new Metadata(System.Guid.Empty, "my name"), "my name", null],
+        [new Metadata(System.Guid.Empty, description: "my description"), null, "my description"],
+        [new Metadata(System.Guid.Empty, "a name", "a description"), "a name", "a description"]
+    ];
+
+    private static void CheckMetadata(string? expectedName, string? expectedDescription, Metadata actual)
+    {
+        actual.Id.Should().BeEmpty();
+        actual.Name.Should().Be(expectedName);
+        actual.Description.Should().Be(expectedDescription);
+    }
+
+    private static void CheckDefaultMetadata(Metadata actual)
+    {
+        actual.Id.Should().NotBeEmpty();
+        actual.Name.Should().BeNull();
+        actual.Description.Should().BeNull();
+    }
+
+    #region GoalStructure combinator tests
+
+    [Theory]
+    [MemberData(nameof(Metadatas))]
+    public void FirstOfGoalStructureCombinator_WhenCalled_GivesExpectedGoalStructure
+        (Metadata metadata, string? expectedName, string? expectedDescription)
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        goalStructure1.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+        goalStructure2.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        FirstOfGoalStructure<IBeliefSet> firstOfGoalStructure =
+            FirstOf(metadata, goalStructure1.Object, goalStructure2.Object);
+        firstOfGoalStructure.UpdateStatus(beliefSet);
+        firstOfGoalStructure.UpdateStatus(beliefSet);
+
+        // Assert
+        CheckMetadata(expectedName, expectedDescription, firstOfGoalStructure.Metadata);
+        firstOfGoalStructure.Status.Should().Be(CompletionStatus.Success);
+        goalStructure1.Verify(x => x.UpdateStatus(It.IsAny<IBeliefSet>()), Times.Once);
+        goalStructure2.Verify(x => x.UpdateStatus(It.IsAny<IBeliefSet>()), Times.Never);
+    }
+
+    [Fact]
+    public void FirstOfGoalStructureCombinator_WithoutMetadata_GivesExpectedGoalStructure()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        goalStructure1.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+        goalStructure2.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        FirstOfGoalStructure<IBeliefSet> firstOfGoalStructure =
+            FirstOf(goalStructure1.Object, goalStructure2.Object);
+        firstOfGoalStructure.UpdateStatus(beliefSet);
+        firstOfGoalStructure.UpdateStatus(beliefSet);
+
+        // Assert
+        CheckDefaultMetadata(firstOfGoalStructure.Metadata);
+        firstOfGoalStructure.Status.Should().Be(CompletionStatus.Success);
+        goalStructure1.Verify(x => x.UpdateStatus(It.IsAny<IBeliefSet>()), Times.Once);
+        goalStructure2.Verify(x => x.UpdateStatus(It.IsAny<IBeliefSet>()), Times.Never);
+    }
+
+    [Theory]
+    [MemberData(nameof(Metadatas))]
+    public void PrimitiveGoalStructureCombinator_WhenCalled_GivesExpectedGoalStructure
+        (Metadata metadata, string? expectedName, string? expectedDescription)
+    {
+        // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Success);
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = Primitive(metadata, goal.Object);
+        primitiveGoalStructure.UpdateStatus(beliefSet);
+
+        // Assert
+        CheckMetadata(expectedName, expectedDescription, primitiveGoalStructure.Metadata);
+        primitiveGoalStructure.Status.Should().Be(CompletionStatus.Success);
+    }
+
+    [Fact]
+    public void PrimitiveGoalStructureCombinator_WithoutMetadata_GivesExpectedGoalStructure()
+    {
+        // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Success);
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = Primitive(goal.Object);
+        primitiveGoalStructure.UpdateStatus(beliefSet);
+
+        // Assert
+        CheckDefaultMetadata(primitiveGoalStructure.Metadata);
+        primitiveGoalStructure.Status.Should().Be(CompletionStatus.Success);
+    }
+
+    [Theory]
+    [MemberData(nameof(Metadatas))]
+    public void RepeatGoalStructureCombinator_WhenCalled_GivesExpectedGoalStructure
+        (Metadata metadata, string? expectedName, string? expectedDescription)
+    {
+        // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Failure);
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = Repeat(metadata, Primitive(goal.Object));
+        repeatGoalStructure.UpdateStatus(beliefSet);
+        IGoal<IBeliefSet> currentGoal = repeatGoalStructure.GetCurrentGoal(beliefSet);
+
+        // Assert
+        CheckMetadata(expectedName, expectedDescription, repeatGoalStructure.Metadata);
+        repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
+        currentGoal.Should().Be(goal.Object);
+    }
+
+    [Fact]
+    public void RepeatGoalStructureCombinator_WithoutMetadata_GivesExpectedGoalStructure()
+    {
+        // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Failure);
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = Repeat(Primitive(goal.Object));
+        repeatGoalStructure.UpdateStatus(beliefSet);
+        IGoal<IBeliefSet> currentGoal = repeatGoalStructure.GetCurrentGoal(beliefSet);
+
+        // Assert
+        CheckDefaultMetadata(repeatGoalStructure.Metadata);
+        repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
+        currentGoal.Should().Be(goal.Object);
+    }
+
+    [Theory]
+    [MemberData(nameof(Metadatas))]
+    public void SequentialGoalStructureCombinator_WhenCalled_GivesExpectedGoalStructure
+        (Metadata metadata, string? expectedName, string? expectedDescription)
+    {
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        goalStructure1.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+        goalStructure2.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        SequentialGoalStructure<IBeliefSet> sequentialGoalStructure =
+            Seq(metadata, goalStructure1.Object, goalStructure2.Object);
+        sequentialGoalStructure.UpdateStatus(beliefSet);
+        sequentialGoalStructure.UpdateStatus(beliefSet);
+
+        // Assert
+        CheckMetadata(expectedName, expectedDescription, sequentialGoalStructure.Metadata);
+        sequentialGoalStructure.Status.Should().Be(CompletionStatus.Success);
+        goalStructure1.Verify(x => x.UpdateStatus(It.IsAny<IBeliefSet>()), Times.Once);
+    }
+
+    [Fact]
+    public void SequentialGoalStructureCombinator_WithoutMetadata_GivesExpectedGoalStructure()
+    {
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        goalStructure1.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+        goalStructure2.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+
+        // Act
+        SequentialGoalStructure<IBeliefSet> sequentialGoalStructure = Seq(goalStructure1.Object, goalStructure2.Object);
+        sequentialGoalStructure.UpdateStatus(beliefSet);
+        sequentialGoalStructure.UpdateStatus(beliefSet);
+
+        // Assert
+        CheckDefaultMetadata(sequentialGoalStructure.Metadata);
+        sequentialGoalStructure.Status.Should().Be(CompletionStatus.Success);
+        goalStructure1.Verify(x => x.UpdateStatus(It.IsAny<IBeliefSet>()), Times.Once);
+    }
+
+    #endregion
+}

--- a/Aplib.Core/Combinators.cs
+++ b/Aplib.Core/Combinators.cs
@@ -11,6 +11,8 @@ namespace Aplib.Core
     /// </summary>
     public static class Combinators
     {
+        #region GoalSructure combinators
+
         /// <inheritdoc cref="FirstOfGoalStructure{TBeliefSet}(Metadata,IGoalStructure{TBeliefSet}[])" />
         public static FirstOfGoalStructure<TBeliefSet> FirstOf<TBeliefSet>
             (Metadata metadata, params IGoalStructure<TBeliefSet>[] children)
@@ -54,6 +56,10 @@ namespace Aplib.Core
         public static SequentialGoalStructure<TBeliefSet> Seq<TBeliefSet>(params IGoalStructure<TBeliefSet>[] children)
             where TBeliefSet : IBeliefSet =>
             new(children);
+
+        #endregion
+
+        #region Tactic combinators
 
         /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(Metadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
         public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>
@@ -145,5 +151,7 @@ namespace Aplib.Core
         public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>(IQueryable<TBeliefSet> query)
             where TBeliefSet : IBeliefSet =>
             new(query);
+
+        #endregion
     }
 }

--- a/Aplib.Core/Combinators.cs
+++ b/Aplib.Core/Combinators.cs
@@ -11,7 +11,7 @@ namespace Aplib.Core
     /// </summary>
     public static class Combinators
     {
-        #region GoalSructure combinators
+        #region GoalStructure combinators
 
         /// <inheritdoc cref="FirstOfGoalStructure{TBeliefSet}(Metadata,IGoalStructure{TBeliefSet}[])" />
         public static FirstOfGoalStructure<TBeliefSet> FirstOf<TBeliefSet>

--- a/Aplib.Core/Combinators.cs
+++ b/Aplib.Core/Combinators.cs
@@ -1,0 +1,149 @@
+using Aplib.Core.Belief.BeliefSets;
+using Aplib.Core.Desire.Goals;
+using Aplib.Core.Desire.GoalStructures;
+using Aplib.Core.Intent.Actions;
+using Aplib.Core.Intent.Tactics;
+
+namespace Aplib.Core
+{
+    /// <summary>
+    /// Convenience class containing static methods for creating goal structures and tactics.
+    /// </summary>
+    public static class Combinators
+    {
+        /// <inheritdoc cref="FirstOfGoalStructure{TBeliefSet}(Metadata,IGoalStructure{TBeliefSet}[])" />
+        public static FirstOfGoalStructure<TBeliefSet> FirstOf<TBeliefSet>
+            (Metadata metadata, params IGoalStructure<TBeliefSet>[] children)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, children);
+
+        /// <inheritdoc cref="FirstOfGoalStructure{TBeliefSet}(IGoalStructure{TBeliefSet}[])" />
+        public static FirstOfGoalStructure<TBeliefSet> FirstOf<TBeliefSet>(params IGoalStructure<TBeliefSet>[] children)
+            where TBeliefSet : IBeliefSet =>
+            new(children);
+
+        /// <inheritdoc cref="PrimitiveGoalStructure{TBeliefSet}(Metadata,IGoal{TBeliefSet})" />
+        public static PrimitiveGoalStructure<TBeliefSet> Primitive<TBeliefSet>
+            (Metadata metadata, IGoal<TBeliefSet> goal)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, goal);
+
+        /// <inheritdoc cref="PrimitiveGoalStructure{TBeliefSet}(IGoal{TBeliefSet})" />
+        public static PrimitiveGoalStructure<TBeliefSet> Primitive<TBeliefSet>(IGoal<TBeliefSet> goal)
+            where TBeliefSet : IBeliefSet =>
+            new(goal);
+
+        /// <inheritdoc cref="RepeatGoalStructure{TBeliefSet}(Metadata,IGoalStructure{TBeliefSet})" />
+        public static RepeatGoalStructure<TBeliefSet> Repeat<TBeliefSet>
+            (Metadata metadata, IGoalStructure<TBeliefSet> goalStructure)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, goalStructure);
+
+        /// <inheritdoc cref="RepeatGoalStructure{TBeliefSet}(IGoalStructure{TBeliefSet})" />
+        public static RepeatGoalStructure<TBeliefSet> Repeat<TBeliefSet>(IGoalStructure<TBeliefSet> goalStructure)
+            where TBeliefSet : IBeliefSet =>
+            new(goalStructure);
+
+        /// <inheritdoc cref="SequentialGoalStructure{TBeliefSet}(Metadata,IGoalStructure{TBeliefSet}[])" />
+        public static SequentialGoalStructure<TBeliefSet> Seq<TBeliefSet>
+            (Metadata metadata, params IGoalStructure<TBeliefSet>[] children)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, children);
+
+        /// <inheritdoc cref="SequentialGoalStructure{TBeliefSet}(IGoalStructure{TBeliefSet}[])" />
+        public static SequentialGoalStructure<TBeliefSet> Seq<TBeliefSet>(params IGoalStructure<TBeliefSet>[] children)
+            where TBeliefSet : IBeliefSet =>
+            new(children);
+
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(Metadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>
+            (Metadata metadata, System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, guard, subTactics);
+
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>
+            (System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(guard, subTactics);
+
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(Metadata,ITactic{TBeliefSet}[])" />
+        public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>
+            (Metadata metadata, params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, subTactics);
+
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(ITactic{TBeliefSet}[])" />
+        public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>(params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(subTactics);
+
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(Metadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        public static FirstOfTactic<TBeliefSet> FirstOf<TBeliefSet>
+            (Metadata metadata, System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, guard, subTactics);
+
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        public static FirstOfTactic<TBeliefSet> FirstOf<TBeliefSet>
+            (System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(guard, subTactics);
+
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(Metadata,ITactic{TBeliefSet}[])"/>
+        public static FirstOfTactic<TBeliefSet> FirstOf<TBeliefSet>
+            (Metadata metadata, params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, subTactics);
+
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(ITactic{TBeliefSet}[])"/>
+        public static FirstOfTactic<TBeliefSet> FirstOf<TBeliefSet>(params ITactic<TBeliefSet>[] subTactics)
+            where TBeliefSet : IBeliefSet =>
+            new(subTactics);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(Metadata,IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
+            (Metadata metadata, IAction<TBeliefSet> action, System.Func<TBeliefSet, bool> guard)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, action, guard);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
+            (IAction<TBeliefSet> action, System.Func<TBeliefSet, bool> guard)
+            where TBeliefSet : IBeliefSet =>
+            new(action, guard);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(Metadata,IAction{TBeliefSet})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>(Metadata metadata, IAction<TBeliefSet> action)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, action);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IAction{TBeliefSet})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>(IAction<TBeliefSet> action)
+            where TBeliefSet : IBeliefSet =>
+            new(action);
+
+        /// <inheritdoc
+        ///     cref="PrimitiveTactic{TBeliefSet}(Metadata,IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
+            (Metadata metadata, IQueryable<TBeliefSet> query, System.Func<TBeliefSet, bool> guard)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, query, guard);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
+            (IQueryable<TBeliefSet> query, System.Func<TBeliefSet, bool> guard)
+            where TBeliefSet : IBeliefSet =>
+            new(query, guard);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(Metadata,IQueryable{TBeliefSet})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>(Metadata metadata, IQueryable<TBeliefSet> query)
+            where TBeliefSet : IBeliefSet =>
+            new(metadata, query);
+
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet})"/>
+        public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>(IQueryable<TBeliefSet> query)
+            where TBeliefSet : IBeliefSet =>
+            new(query);
+    }
+}

--- a/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
@@ -39,7 +39,7 @@ namespace Aplib.Core.Desire.GoalStructures
             _currentGoalStructure = _childrenEnumerator.Current;
         }
 
-        /// <inheritdoc cref="SequentialGoalStructure{TBeliefSet}(Metadata?,IGoalStructure{TBeliefSet}[])" />
+        /// <inheritdoc cref="SequentialGoalStructure{TBeliefSet}(Metadata,IGoalStructure{TBeliefSet}[])" />
         public SequentialGoalStructure(params IGoalStructure<TBeliefSet>[] children) : this(new Metadata(), children)
         {
         }

--- a/Aplib.Core/Intent/Tactics/PrimitiveTactic.cs
+++ b/Aplib.Core/Intent/Tactics/PrimitiveTactic.cs
@@ -66,13 +66,15 @@ namespace Aplib.Core.Intent.Tactics
         {
         }
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})" />
+        /// <inheritdoc
+        ///     cref="PrimitiveTactic{TBeliefSet}(Metadata,IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
         public PrimitiveTactic(Metadata metadata, IQueryable<TBeliefSet> queryAction)
             : this(metadata, queryAction, _ => true)
         {
         }
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})" />
+        /// <inheritdoc
+        ///     cref="PrimitiveTactic{TBeliefSet}(Metadata,IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
         public PrimitiveTactic(IQueryable<TBeliefSet> queryAction)
             : this(new Metadata(), queryAction, _ => true)
         {


### PR DESCRIPTION
## Description

This PR adds static methods which are wrappers around the constructors of goal structures and tactics, so the user does not have to write `new` every time.

The user should now be able to create a snippet looking something like this:
```cs
GoalStructure gs = FirstOf(Primitive(...));
Tactic t = FirstOf(AnyOf(...), AnyOf(...));
```

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch