### PR TITLE
fix: check guards in `AnyOfTactic` and `FirstOfTactic`

### DIFF
--- a/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
+++ b/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
@@ -170,6 +170,21 @@ public class TacticTests
     }
 
     [Fact]
+    public void AnyOfTactic_WithFailingGuard_ReturnsNoAction()
+    {
+        // Arrange
+        Action<IBeliefSet> action1 = new(_ => { });
+        PrimitiveTactic<IBeliefSet> tactic1 = new(action1, _ => true);
+        AnyOfTactic<IBeliefSet> parentTactic = new(_ => false, tactic1);
+
+        // Act
+        IAction<IBeliefSet>? selectedAction = parentTactic.GetAction(It.IsAny<IBeliefSet>());
+
+        // Assert
+        selectedAction.Should().BeNull();
+    }
+
+    [Fact]
     public void FirstOfTacticTactic_WhenConstructed_HasExpectedData()
     {
         // Arrange
@@ -279,6 +294,21 @@ public class TacticTests
 
         // Assert
         selectedAction.Should().Be(action2);
+    }
+
+    [Fact]
+    public void FirstOfTactic_WithFailingGuard_ReturnsNoAction()
+    {
+        // Arrange
+        Action<IBeliefSet> action1 = new(_ => { });
+        PrimitiveTactic<IBeliefSet> tactic1 = new(action1, _ => true);
+        FirstOfTactic<IBeliefSet> parentTactic = new(_ => false, tactic1);
+
+        // Act
+        IAction<IBeliefSet>? selectedAction = parentTactic.GetAction(It.IsAny<IBeliefSet>());
+
+        // Assert
+        selectedAction.Should().BeNull();
     }
 
     /// <summary>

--- a/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
+++ b/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
@@ -170,12 +170,12 @@ public class TacticTests
     }
 
     [Fact]
-    public void AnyOfTactic_WithFailingGuard_ReturnsNoAction()
+    public void AnyOfTactic_WithFalseGuard_ReturnsNoAction()
     {
         // Arrange
-        Action<IBeliefSet> action1 = new(_ => { });
-        PrimitiveTactic<IBeliefSet> tactic1 = new(action1, _ => true);
-        AnyOfTactic<IBeliefSet> parentTactic = new(_ => false, tactic1);
+        Action<IBeliefSet> action = new(_ => { });
+        PrimitiveTactic<IBeliefSet> tactic = new(action, _ => true);
+        AnyOfTactic<IBeliefSet> parentTactic = new(_ => false, tactic);
 
         // Act
         IAction<IBeliefSet>? selectedAction = parentTactic.GetAction(It.IsAny<IBeliefSet>());
@@ -297,12 +297,12 @@ public class TacticTests
     }
 
     [Fact]
-    public void FirstOfTactic_WithFailingGuard_ReturnsNoAction()
+    public void FirstOfTactic_WithFalseGuard_ReturnsNoAction()
     {
         // Arrange
-        Action<IBeliefSet> action1 = new(_ => { });
-        PrimitiveTactic<IBeliefSet> tactic1 = new(action1, _ => true);
-        FirstOfTactic<IBeliefSet> parentTactic = new(_ => false, tactic1);
+        Action<IBeliefSet> action = new(_ => { });
+        PrimitiveTactic<IBeliefSet> tactic = new(action, _ => true);
+        FirstOfTactic<IBeliefSet> parentTactic = new(_ => false, tactic);
 
         // Act
         IAction<IBeliefSet>? selectedAction = parentTactic.GetAction(It.IsAny<IBeliefSet>());

--- a/Aplib.Core/Intent/Tactics/AnyOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/AnyOfTactic.cs
@@ -54,6 +54,8 @@ namespace Aplib.Core.Intent.Tactics
         /// <inheritdoc/>
         public override IAction<TBeliefSet>? GetAction(TBeliefSet beliefSet)
         {
+            if (!IsActionable(beliefSet)) return null;
+
             List<IAction<TBeliefSet>> actions = new();
 
             foreach (ITactic<TBeliefSet> subTactic in _subTactics)

--- a/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
@@ -43,6 +43,8 @@ namespace Aplib.Core.Intent.Tactics
         /// <inheritdoc />
         public override IAction<TBeliefSet>? GetAction(TBeliefSet beliefSet)
         {
+            if (!IsActionable(beliefSet)) return null;
+
             foreach (ITactic<TBeliefSet> subTactic in _subTactics)
             {
                 IAction<TBeliefSet>? action = subTactic.GetAction(beliefSet);

--- a/Aplib.Core/Intent/Tactics/PrimitiveTactic.cs
+++ b/Aplib.Core/Intent/Tactics/PrimitiveTactic.cs
@@ -81,8 +81,5 @@ namespace Aplib.Core.Intent.Tactics
         /// <inheritdoc/>
         public override IAction<TBeliefSet>? GetAction(TBeliefSet beliefSet)
             => IsActionable(beliefSet) ? _action : null;
-
-        /// <inheritdoc/>
-        public override bool IsActionable(TBeliefSet beliefSet) => base.IsActionable(beliefSet);
     }
 }


### PR DESCRIPTION
## Description

Currently the guards of `AnyOfTactic` and `FirstOfTactic`  are completely unused, the guards of the subtactics are used but not those of the `AnyOfTactic`/`FirstOfTactic` themselves.

This PR adds a check to `GetAction` method of both classes that checks the guard.

A redundant override of `IsActionable` in `PrimitiveTactic` is also removed.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch