### PR TITLE
feat!: add fail-guard to Goal

### DIFF
--- a/Aplib.Core.Tests/Belief/BeliefTests.cs
+++ b/Aplib.Core.Tests/Belief/BeliefTests.cs
@@ -1,7 +1,6 @@
 ﻿using Aplib.Core.Belief.Beliefs;
 using FluentAssertions;
 using Moq;
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,32 +36,33 @@ public class BeliefTests
     {
         public object Reference => _reference;
 
-        public Func<object, object> GetObservationFromReference => _getObservationFromReference;
+        public System.Func<object, object> GetObservationFromReference => _getObservationFromReference;
 
-        public Func<bool> ShouldUpdate => _shouldUpdate;
+        public System.Func<bool> ShouldUpdate => _shouldUpdate;
 
         public TestBelief
         (
             Metadata metadata,
             object reference,
-            Func<object, object> getObservationFromReference,
-            Func<bool> shouldUpdate
+            System.Func<object, object> getObservationFromReference,
+            System.Func<bool> shouldUpdate
         )
             : base(metadata, reference, getObservationFromReference, shouldUpdate)
         {
         }
 
-        public TestBelief(object reference, Func<object, object> getObservationFromReference, Func<bool> shouldUpdate)
+        public TestBelief
+            (object reference, System.Func<object, object> getObservationFromReference, System.Func<bool> shouldUpdate)
             : base(reference, getObservationFromReference, shouldUpdate)
         {
         }
 
-        public TestBelief(Metadata metadata, object reference, Func<object, object> getObservationFromReference)
+        public TestBelief(Metadata metadata, object reference, System.Func<object, object> getObservationFromReference)
             : base(metadata, reference, getObservationFromReference)
         {
         }
 
-        public TestBelief(object reference, Func<object, object> getObservationFromReference)
+        public TestBelief(object reference, System.Func<object, object> getObservationFromReference)
             : base(reference, getObservationFromReference)
         {
         }
@@ -74,8 +74,8 @@ public class BeliefTests
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
-        Func<bool> shouldUpdate = It.IsAny<Func<bool>>();
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
+        System.Func<bool> shouldUpdate = It.IsAny<System.Func<bool>>();
 
         // Act
         TestBelief belief = new(metadata, reference, getObservationFromReference, shouldUpdate);
@@ -92,8 +92,8 @@ public class BeliefTests
     {
         // Arrange
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
-        Func<bool> shouldUpdate = It.IsAny<Func<bool>>();
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
+        System.Func<bool> shouldUpdate = It.IsAny<System.Func<bool>>();
 
         // Act
         TestBelief belief = new(reference, getObservationFromReference, shouldUpdate);
@@ -113,7 +113,7 @@ public class BeliefTests
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
 
         // Act
         TestBelief belief = new(metadata, reference, getObservationFromReference);
@@ -130,7 +130,7 @@ public class BeliefTests
     {
         // Arrange
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
 
         // Act
         TestBelief belief = new(reference, getObservationFromReference);
@@ -176,14 +176,14 @@ public class BeliefTests
         const string paramName = "reference";
 
         // ReSharper disable once ConvertToLocalFunction
-        Action construction = () =>
+        System.Action construction = () =>
         {
             // The bug is the fact that we can get around the constraint that `TReference` should be a reference type.
             _ = new Belief<IEnumerable<int>, List<int>>(value, values => values.ToList());
         };
 
         // Act, Assert
-        Assert.Throws<ArgumentException>(paramName, construction);
+        Assert.Throws<System.ArgumentException>(paramName, construction);
     }
 
     /// <summary>

--- a/Aplib.Core.Tests/Belief/MemoryBeliefTests.cs
+++ b/Aplib.Core.Tests/Belief/MemoryBeliefTests.cs
@@ -2,7 +2,6 @@ using Aplib.Core.Belief.Beliefs;
 using Aplib.Core.Collections;
 using FluentAssertions;
 using Moq;
-using System;
 using System.Collections.Generic;
 
 namespace Aplib.Core.Tests.Belief;
@@ -16,9 +15,9 @@ public class MemoryBeliefTests
     {
         public object Reference => _reference;
 
-        public Func<object, object> GetObservationFromReference => _getObservationFromReference;
+        public System.Func<object, object> GetObservationFromReference => _getObservationFromReference;
 
-        public Func<bool> ShouldUpdate => _shouldUpdate;
+        public System.Func<bool> ShouldUpdate => _shouldUpdate;
 
         public ExposedQueue<object> MemorizedObservations => _memorizedObservations;
 
@@ -26,9 +25,9 @@ public class MemoryBeliefTests
         (
             Metadata metadata,
             object reference,
-            Func<object, object> getObservationFromReference,
+            System.Func<object, object> getObservationFromReference,
             int framesToRemember,
-            Func<bool> shouldUpdate
+            System.Func<bool> shouldUpdate
         )
             : base(metadata, reference, getObservationFromReference, framesToRemember, shouldUpdate)
         {
@@ -37,9 +36,9 @@ public class MemoryBeliefTests
         public TestMemoryBelief
         (
             object reference,
-            Func<object, object> getObservationFromReference,
+            System.Func<object, object> getObservationFromReference,
             int framesToRemember,
-            Func<bool> shouldUpdate
+            System.Func<bool> shouldUpdate
         )
             : base(reference, getObservationFromReference, framesToRemember, shouldUpdate)
         {
@@ -49,7 +48,7 @@ public class MemoryBeliefTests
         (
             Metadata metadata,
             object reference,
-            Func<object, object> getObservationFromReference,
+            System.Func<object, object> getObservationFromReference,
             int framesToRemember
         )
             : base(metadata, reference, getObservationFromReference, framesToRemember)
@@ -57,7 +56,7 @@ public class MemoryBeliefTests
         }
 
         public TestMemoryBelief
-            (object reference, Func<object, object> getObservationFromReference, int framesToRemember)
+            (object reference, System.Func<object, object> getObservationFromReference, int framesToRemember)
             : base(reference, getObservationFromReference, framesToRemember)
         {
         }
@@ -69,9 +68,9 @@ public class MemoryBeliefTests
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
         const int framesToRemember = 0;
-        Func<bool> shouldUpdate = It.IsAny<Func<bool>>();
+        System.Func<bool> shouldUpdate = It.IsAny<System.Func<bool>>();
 
         // Act
         TestMemoryBelief belief = new(metadata, reference, getObservationFromReference, framesToRemember, shouldUpdate);
@@ -89,9 +88,9 @@ public class MemoryBeliefTests
     {
         // Arrange
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
         const int framesToRemember = 1;
-        Func<bool> shouldUpdate = It.IsAny<Func<bool>>();
+        System.Func<bool> shouldUpdate = It.IsAny<System.Func<bool>>();
 
         // Act
         TestMemoryBelief belief = new(reference, getObservationFromReference, framesToRemember, shouldUpdate);
@@ -112,7 +111,7 @@ public class MemoryBeliefTests
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
         const int framesToRemember = 2;
 
         // Act
@@ -131,7 +130,7 @@ public class MemoryBeliefTests
     {
         // Arrange
         object reference = new Mock<object>().Object;
-        Func<object, object> getObservationFromReference = new Mock<Func<object, object>>().Object;
+        System.Func<object, object> getObservationFromReference = new Mock<System.Func<object, object>>().Object;
         const int framesToRemember = 3;
 
         // Act
@@ -207,8 +206,8 @@ public class MemoryBeliefTests
         void GetMemoryAtIndexGreaterThanCount() => belief.GetMemoryAt(3);
 
         // Assert
-        Assert.Throws<ArgumentOutOfRangeException>(GetMemoryAtNegativeIndex);
-        Assert.Throws<ArgumentOutOfRangeException>(GetMemoryAtIndexGreaterThanCount);
+        Assert.Throws<System.ArgumentOutOfRangeException>(GetMemoryAtNegativeIndex);
+        Assert.Throws<System.ArgumentOutOfRangeException>(GetMemoryAtIndexGreaterThanCount);
     }
 
     /// <summary>

--- a/Aplib.Core.Tests/Collections/ExposedQueueTests.cs
+++ b/Aplib.Core.Tests/Collections/ExposedQueueTests.cs
@@ -1,5 +1,4 @@
 using Aplib.Core.Collections;
-using System;
 using System.Collections.Generic;
 
 namespace Aplib.Core.Tests.Collections;
@@ -13,7 +12,7 @@ public class ExposedQueueTests
         void AccessIndexGreaterThanCount() => _ = new ExposedQueue<int>(3)[4];
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(AccessIndexGreaterThanCount);
+        Assert.Throws<System.ArgumentOutOfRangeException>(AccessIndexGreaterThanCount);
     }
 
     [Fact]
@@ -23,7 +22,7 @@ public class ExposedQueueTests
         void AccessNegativeIndex() => _ = new ExposedQueue<int>(3)[-1];
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(AccessNegativeIndex);
+        Assert.Throws<System.ArgumentOutOfRangeException>(AccessNegativeIndex);
     }
 
     [Fact]
@@ -89,7 +88,7 @@ public class ExposedQueueTests
         ExposedQueue<int> queue = new([3, 2, 1]);
 
         // Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => queue.CopyTo(new int[3], 0, 3));
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => queue.CopyTo(new int[3], 0, 3));
     }
 
     [Fact]
@@ -99,7 +98,7 @@ public class ExposedQueueTests
         ExposedQueue<int> queue = new([3, 2, 1]);
 
         // Assert
-        Assert.Throws<ArgumentException>(() => queue.CopyTo(new int[3], 2, 1));
+        Assert.Throws<System.ArgumentException>(() => queue.CopyTo(new int[3], 2, 1));
     }
 
     [Fact]
@@ -109,7 +108,7 @@ public class ExposedQueueTests
         ExposedQueue<int> queue = new([3, 2, 1]);
 
         // Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => queue.CopyTo(new int[3], -1, 2));
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => queue.CopyTo(new int[3], -1, 2));
     }
 
     [Fact]
@@ -227,7 +226,7 @@ public class ExposedQueueTests
         void NegativeCount() => _ = new ExposedQueue<int>([1, 2, 3], -1);
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(NegativeCount);
+        Assert.Throws<System.ArgumentOutOfRangeException>(NegativeCount);
     }
 
     [Fact]

--- a/Aplib.Core.Tests/CombinatorTests.cs
+++ b/Aplib.Core.Tests/CombinatorTests.cs
@@ -96,7 +96,7 @@ public class CombinatorTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Success);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
 
         // Act
@@ -114,7 +114,7 @@ public class CombinatorTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Success);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
 
         // Act
@@ -134,7 +134,7 @@ public class CombinatorTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Failure);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Failure);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
 
         // Act
@@ -154,7 +154,7 @@ public class CombinatorTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Failure);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Failure);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
 
         // Act

--- a/Aplib.Core.Tests/CombinatorTests.cs
+++ b/Aplib.Core.Tests/CombinatorTests.cs
@@ -231,7 +231,7 @@ public class CombinatorTests
         Action<IBeliefSet> action1 = new(_ => { });
         Action<IBeliefSet> action2 = new(_ => { });
         // ReSharper disable once ConvertToLocalFunction
-        System.Func<IBeliefSet, bool> guard = _ => false;
+        System.Predicate<IBeliefSet> guard = _ => false;
 
         // Act
         AnyOfTactic<IBeliefSet> anyOfTactic =
@@ -251,7 +251,7 @@ public class CombinatorTests
         Action<IBeliefSet> action1 = new(_ => { });
         Action<IBeliefSet> action2 = new(_ => { });
         // ReSharper disable once ConvertToLocalFunction
-        System.Func<IBeliefSet, bool> guard = _ => false;
+        System.Predicate<IBeliefSet> guard = _ => false;
 
         // Act
         AnyOfTactic<IBeliefSet> anyOfTactic =
@@ -310,7 +310,7 @@ public class CombinatorTests
         Action<IBeliefSet> action1 = new(_ => { });
         Action<IBeliefSet> action2 = new(_ => { });
         // ReSharper disable once ConvertToLocalFunction
-        System.Func<IBeliefSet, bool> guard = _ => false;
+        System.Predicate<IBeliefSet> guard = _ => false;
 
         // Act
         FirstOfTactic<IBeliefSet> firstOfTactic =
@@ -330,7 +330,7 @@ public class CombinatorTests
         Action<IBeliefSet> action1 = new(_ => { });
         Action<IBeliefSet> action2 = new(_ => { });
         // ReSharper disable once ConvertToLocalFunction
-        System.Func<IBeliefSet, bool> guard = _ => false;
+        System.Predicate<IBeliefSet> guard = _ => false;
 
         // Act
         FirstOfTactic<IBeliefSet> firstOfTactic =
@@ -388,7 +388,7 @@ public class CombinatorTests
     {
         // Arrange
         Action<IBeliefSet> action = new(_ => { });
-        Mock<System.Func<IBeliefSet, bool>> guard = new();
+        Mock<System.Predicate<IBeliefSet>> guard = new();
         guard.SetupSequence(f => f(It.IsAny<IBeliefSet>())).Returns(false).Returns(true);
 
         // Act
@@ -408,7 +408,7 @@ public class CombinatorTests
     {
         // Arrange
         Action<IBeliefSet> action = new(_ => { });
-        Mock<System.Func<IBeliefSet, bool>> guard = new();
+        Mock<System.Predicate<IBeliefSet>> guard = new();
         guard.SetupSequence(f => f(It.IsAny<IBeliefSet>())).Returns(false).Returns(true);
 
         // Act
@@ -470,7 +470,7 @@ public class CombinatorTests
         Mock<System.Func<IBeliefSet, int>> query = new();
         query.SetupSequence(f => f(It.IsAny<IBeliefSet>())).Returns(1).Returns(2);
         QueryAction<IBeliefSet, int> queryAction = new((_, _) => { }, query.Object);
-        Mock<System.Func<IBeliefSet, bool>> guard = new();
+        Mock<System.Predicate<IBeliefSet>> guard = new();
         guard.SetupSequence(f => f(It.IsAny<IBeliefSet>())).Returns(false).Returns(true);
 
         // Act
@@ -492,7 +492,7 @@ public class CombinatorTests
         Mock<System.Func<IBeliefSet, int>> query = new();
         query.SetupSequence(f => f(It.IsAny<IBeliefSet>())).Returns(1).Returns(2);
         QueryAction<IBeliefSet, int> queryAction = new((_, _) => { }, query.Object);
-        Mock<System.Func<IBeliefSet, bool>> guard = new();
+        Mock<System.Predicate<IBeliefSet>> guard = new();
         guard.SetupSequence(f => f(It.IsAny<IBeliefSet>())).Returns(false).Returns(true);
 
         // Act

--- a/Aplib.Core.Tests/Desire/DesireSetTests.cs
+++ b/Aplib.Core.Tests/Desire/DesireSetTests.cs
@@ -4,7 +4,6 @@ using Aplib.Core.Desire.Goals;
 using Aplib.Core.Desire.GoalStructures;
 using FluentAssertions;
 using Moq;
-using System;
 
 namespace Aplib.Core.Tests.Desire;
 
@@ -29,10 +28,10 @@ public class DesireSetTests
 
         // Act
         desireSet.Update(It.IsAny<IBeliefSet>());
-        Action getCurrentGoal = () => desireSet.GetCurrentGoal(It.IsAny<IBeliefSet>());
+        System.Action getCurrentGoal = () => desireSet.GetCurrentGoal(It.IsAny<IBeliefSet>());
 
         // Assert
-        getCurrentGoal.Should().Throw<InvalidOperationException>();
+        getCurrentGoal.Should().Throw<System.InvalidOperationException>();
     }
 
     /// <summary>

--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -182,7 +182,7 @@ public class GoalStructureTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(status);
+        goal.Setup(g => g.Status).Returns(status);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
 
@@ -198,7 +198,7 @@ public class GoalStructureTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Unfinished);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Unfinished);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
 
@@ -215,7 +215,7 @@ public class GoalStructureTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Unfinished);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Unfinished);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
         RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);
@@ -234,7 +234,7 @@ public class GoalStructureTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Failure);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Failure);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
         RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);
@@ -253,7 +253,7 @@ public class GoalStructureTests
     {
         // Arrange
         Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.GetStatus(It.IsAny<IBeliefSet>())).Returns(CompletionStatus.Success);
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
         RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);

--- a/Aplib.Core.Tests/Desire/GoalTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalTests.cs
@@ -172,4 +172,21 @@ public class GoalTests
         // Assert
         goalBooleanEvaluation.Should().Be(goalNonBooleanEvaluation);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UpdateStatus_WhenFailGuardIsTrue_FailsTheGoal(bool goalCompleted)
+    {
+        // Arrange
+        ITactic<IBeliefSet> tactic = Mock.Of<ITactic<IBeliefSet>>();
+        Goal<IBeliefSet>.HeuristicFunction heuristic = CommonHeuristicFunctions<IBeliefSet>.Boolean(_ => goalCompleted);
+        Goal<IBeliefSet> goal = new(tactic, heuristic, _ => true);
+
+        // Act
+        goal.UpdateStatus(It.IsAny<IBeliefSet>());
+
+        // Assert
+        goal.Status.Should().Be(CompletionStatus.Failure);
+    }
 }

--- a/Aplib.Core.Tests/Desire/GoalTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalTests.cs
@@ -189,4 +189,21 @@ public class GoalTests
         // Assert
         goal.Status.Should().Be(CompletionStatus.Failure);
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Goal_WithoutFailGuard_DoesNotFail(bool goalCompleted)
+    {
+        // Arrange
+        ITactic<IBeliefSet> tactic = Mock.Of<ITactic<IBeliefSet>>();
+        Goal<IBeliefSet>.HeuristicFunction heuristic = CommonHeuristicFunctions<IBeliefSet>.Boolean(_ => goalCompleted);
+
+        // Act
+        Goal<IBeliefSet> goal = new(tactic, heuristic);
+        goal.UpdateStatus(It.IsAny<IBeliefSet>());
+
+        // Assert
+        goal.Status.Should().NotBe(CompletionStatus.Failure);
+    }
 }

--- a/Aplib.Core.Tests/Desire/GoalTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalTests.cs
@@ -173,14 +173,12 @@ public class GoalTests
         goalBooleanEvaluation.Should().Be(goalNonBooleanEvaluation);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void UpdateStatus_WhenFailGuardIsTrue_FailsTheGoal(bool goalCompleted)
+    [Fact]
+    public void UpdateStatus_WhenFailGuardIsTrue_FailsTheGoal()
     {
         // Arrange
         ITactic<IBeliefSet> tactic = Mock.Of<ITactic<IBeliefSet>>();
-        Goal<IBeliefSet>.HeuristicFunction heuristic = CommonHeuristicFunctions<IBeliefSet>.Boolean(_ => goalCompleted);
+        Goal<IBeliefSet>.HeuristicFunction heuristic = CommonHeuristicFunctions<IBeliefSet>.Boolean(_ => false);
         Goal<IBeliefSet> goal = new(tactic, heuristic, _ => true);
 
         // Act
@@ -188,6 +186,21 @@ public class GoalTests
 
         // Assert
         goal.Status.Should().Be(CompletionStatus.Failure);
+    }
+
+    [Fact]
+    public void UpdateStatus_WhenBothFailGuardIsTrueAndHeuristicIsReached_CompletesTheGoal()
+    {
+        // Arrange
+        ITactic<IBeliefSet> tactic = Mock.Of<ITactic<IBeliefSet>>();
+        Goal<IBeliefSet>.HeuristicFunction heuristic = CommonHeuristicFunctions<IBeliefSet>.Boolean(_ => true);
+        Goal<IBeliefSet> goal = new(tactic, heuristic, _ => true);
+
+        // Act
+        goal.UpdateStatus(It.IsAny<IBeliefSet>());
+
+        // Assert
+        goal.Status.Should().Be(CompletionStatus.Success);
     }
 
     [Theory]

--- a/Aplib.Core.Tests/Desire/GoalTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalTests.cs
@@ -5,6 +5,7 @@ using Aplib.Core.Intent.Tactics;
 using Aplib.Core.Tests.Tools;
 using FluentAssertions;
 using Moq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Aplib.Core.Tests.Desire;
 
@@ -121,12 +122,12 @@ public class GoalTests
     /// the most recent heuristics are used
     /// </summary>
     [Fact]
+    [SuppressMessage("ReSharper", "AccessToModifiedClosure")]
     public void Goal_WhereHeuristicsChange_UsesUpdatedHeuristics()
     {
         // Arrange
         IBeliefSet beliefSetMock = Mock.Of<IBeliefSet>();
         bool shouldSucceed = false;
-        // ReSharper disable once AccessToModifiedClosure
         Goal<IBeliefSet> goal = new TestGoalBuilder().WithHeuristicFunction(_ => shouldSucceed).Build();
 
         // Act
@@ -155,8 +156,6 @@ public class GoalTests
         // Arrange
         ITactic<IBeliefSet> tactic = Mock.Of<ITactic<IBeliefSet>>();
 
-        // ReSharper disable once MoveLocalFunctionAfterJumpStatement
-        bool HeuristicFunctionBoolean(IBeliefSet _) => goalCompleted;
         Goal<IBeliefSet>.HeuristicFunction heuristicFunctionNonBoolean =
             CommonHeuristicFunctions<IBeliefSet>.Boolean(_ => goalCompleted);
 
@@ -171,6 +170,9 @@ public class GoalTests
 
         // Assert
         goalBooleanEvaluation.Should().Be(goalNonBooleanEvaluation);
+        return;
+
+        bool HeuristicFunctionBoolean(IBeliefSet _) => goalCompleted;
     }
 
     [Fact]

--- a/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
+++ b/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
@@ -12,11 +12,11 @@ public class TacticTests
     // A subclass of Tactic for testing
     public class TestTactic : Tactic<IBeliefSet>
     {
-        public System.Func<IBeliefSet, bool> Guard => _guard;
+        public System.Predicate<IBeliefSet> Guard => _guard;
 
-        public TestTactic(Metadata metadata, System.Func<IBeliefSet, bool> guard) : base(metadata, guard) { }
+        public TestTactic(Metadata metadata, System.Predicate<IBeliefSet> guard) : base(metadata, guard) { }
 
-        public TestTactic(System.Func<IBeliefSet, bool> guard) : base(guard) { }
+        public TestTactic(System.Predicate<IBeliefSet> guard) : base(guard) { }
 
         public TestTactic(Metadata metadata) : base(metadata) { }
 
@@ -29,12 +29,12 @@ public class TacticTests
     // A subclass of FirstOfTactic for testing
     public class TestFirstOfTactic : FirstOfTactic<IBeliefSet>
     {
-        public System.Func<IBeliefSet, bool> Guard => _guard;
+        public System.Predicate<IBeliefSet> Guard => _guard;
 
         public LinkedList<ITactic<IBeliefSet>> SubTactics => _subTactics;
 
         public TestFirstOfTactic
-            (Metadata metadata, System.Func<IBeliefSet, bool> guard, params ITactic<IBeliefSet>[] subTactics)
+            (Metadata metadata, System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subTactics)
             : base(metadata, guard, subTactics)
         {
         }
@@ -44,7 +44,7 @@ public class TacticTests
         {
         }
 
-        public TestFirstOfTactic(System.Func<IBeliefSet, bool> guard, params ITactic<IBeliefSet>[] subTactics)
+        public TestFirstOfTactic(System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subTactics)
             : base(guard, subTactics)
         {
         }
@@ -58,7 +58,7 @@ public class TacticTests
     {
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
-        System.Func<IBeliefSet, bool> guard = It.IsAny<System.Func<IBeliefSet, bool>>();
+        System.Predicate<IBeliefSet> guard = It.IsAny<System.Predicate<IBeliefSet>>();
 
         // Act
         TestTactic tactic = new(metadata, guard);
@@ -72,7 +72,7 @@ public class TacticTests
     public void Tactic_WithoutMetadata_HasExpectedData()
     {
         // Arrange
-        System.Func<IBeliefSet, bool> guard = It.IsAny<System.Func<IBeliefSet, bool>>();
+        System.Predicate<IBeliefSet> guard = It.IsAny<System.Predicate<IBeliefSet>>();
 
         // Act
         TestTactic tactic = new(guard);
@@ -189,7 +189,7 @@ public class TacticTests
     {
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
-        System.Func<IBeliefSet, bool> guard = It.IsAny<System.Func<IBeliefSet, bool>>();
+        System.Predicate<IBeliefSet> guard = It.IsAny<System.Predicate<IBeliefSet>>();
         ITactic<IBeliefSet>[] subTactics = [It.IsAny<ITactic<IBeliefSet>>()];
 
         // Act
@@ -221,7 +221,7 @@ public class TacticTests
     public void FirstOfTacticTactic_WithoutMetadata_HasExpectedData()
     {
         // Arrange
-        System.Func<IBeliefSet, bool> guard = It.IsAny<System.Func<IBeliefSet, bool>>();
+        System.Predicate<IBeliefSet> guard = It.IsAny<System.Predicate<IBeliefSet>>();
         ITactic<IBeliefSet>[] subTactics = [It.IsAny<ITactic<IBeliefSet>>()];
 
         // Act

--- a/Aplib.Core.Tests/Tools/TestGoalBuilder.cs
+++ b/Aplib.Core.Tests/Tools/TestGoalBuilder.cs
@@ -18,7 +18,7 @@ internal sealed class TestGoalBuilder
         return this;
     }
 
-    public TestGoalBuilder WithHeuristicFunction(System.Func<IBeliefSet, bool> heuristicFunction)
+    public TestGoalBuilder WithHeuristicFunction(System.Predicate<IBeliefSet> heuristicFunction)
         => WithHeuristicFunction(CommonHeuristicFunctions<IBeliefSet>.Boolean(heuristicFunction));
 
     public TestGoalBuilder UseTactic(ITactic<IBeliefSet> tactic)

--- a/Aplib.Core/Belief/Beliefs/Belief.cs
+++ b/Aplib.Core/Belief/Beliefs/Belief.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Aplib.Core.Belief.Beliefs
+﻿namespace Aplib.Core.Belief.Beliefs
 {
     /// <summary>
     /// The <see cref="Belief{TReference, TObservation}"/> class represents the agent's belief of a single object.
@@ -25,12 +23,12 @@ namespace Aplib.Core.Belief.Beliefs
         /// <summary>
         /// A function that takes an object reference and generates/updates an observation.
         /// </summary>
-        protected readonly Func<TReference, TObservation> _getObservationFromReference;
+        protected readonly System.Func<TReference, TObservation> _getObservationFromReference;
 
         /// <summary>
         /// A condition on when the observation should be updated.
         /// </summary>
-        protected readonly Func<bool> _shouldUpdate;
+        protected readonly System.Func<bool> _shouldUpdate;
 
         /// <summary>
         /// Gets the metadata of the Belief.
@@ -61,20 +59,21 @@ namespace Aplib.Core.Belief.Beliefs
         /// A function that takes an object reference and generates/updates an observation.
         /// </param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// Thrown when <paramref name="reference"/> is not a reference type.
         /// </exception>
         public Belief
         (
             Metadata metadata,
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
-            Func<bool> shouldUpdate
+            System.Func<TReference, TObservation> getObservationFromReference,
+            System.Func<bool> shouldUpdate
         )
         {
-            Type referenceType = reference.GetType();
+            System.Type referenceType = reference.GetType();
             if (referenceType.IsValueType)
-                throw new ArgumentException($"{referenceType.FullName} is not a reference type.", nameof(reference));
+                throw new System.ArgumentException
+                    ($"{referenceType.FullName} is not a reference type.", nameof(reference));
 
             Metadata = metadata;
             _reference = reference;
@@ -84,32 +83,32 @@ namespace Aplib.Core.Belief.Beliefs
         }
 
         /// <inheritdoc
-        ///     cref="Belief{TReference,TObservation}(Aplib.Core.Metadata,TReference,Func{TReference,TObservation},Func{bool})"/>
+        ///     cref="Belief{TReference,TObservation}(Aplib.Core.Metadata,TReference,System.Func{TReference,TObservation},System.Func{bool})"/>
         public Belief
         (
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
-            Func<bool> shouldUpdate
+            System.Func<TReference, TObservation> getObservationFromReference,
+            System.Func<bool> shouldUpdate
         )
             : this(new Metadata(), reference, getObservationFromReference, shouldUpdate)
         {
         }
 
         /// <inheritdoc
-        ///     cref="Belief{TReference,TObservation}(Aplib.Core.Metadata,TReference,Func{TReference,TObservation},Func{bool})" />
+        ///     cref="Belief{TReference,TObservation}(Aplib.Core.Metadata,TReference,System.Func{TReference,TObservation},System.Func{bool})" />
         public Belief
         (
             Metadata metadata,
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference
+            System.Func<TReference, TObservation> getObservationFromReference
         )
             : this(metadata, reference, getObservationFromReference, () => true)
         {
         }
 
         /// <inheritdoc
-        ///     cref="Belief{TReference,TObservation}(Aplib.Core.Metadata,TReference,Func{TReference,TObservation},Func{bool})" />
-        public Belief(TReference reference, Func<TReference, TObservation> getObservationFromReference)
+        ///     cref="Belief{TReference,TObservation}(Aplib.Core.Metadata,TReference,System.Func{TReference,TObservation},System.Func{bool})" />
+        public Belief(TReference reference, System.Func<TReference, TObservation> getObservationFromReference)
             : this(new Metadata(), reference, getObservationFromReference, () => true)
         {
         }

--- a/Aplib.Core/Belief/Beliefs/ListBelief.cs
+++ b/Aplib.Core/Belief/Beliefs/ListBelief.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -37,47 +36,48 @@ namespace Aplib.Core.Belief.Beliefs
         /// A function that takes an object reference and generates an observation.
         /// </param>
         /// <param name="shouldUpdate">A condition on when the observation should be updated.</param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// Thrown when <paramref name="references"/> is not a reference type.
         /// </exception>
         public ListBelief
         (
             Metadata metadata,
             IEnumerable<TReference> references,
-            Func<TReference, TObservation> getObservationFromReference,
-            Func<bool> shouldUpdate
+            System.Func<TReference, TObservation> getObservationFromReference,
+            System.Func<bool> shouldUpdate
         )
             : base(metadata, references, refer => refer.Select(getObservationFromReference).ToList(), shouldUpdate)
         {
         }
 
-        /// <inheritdoc cref="ListBelief{TReference,TObservation}(Metadata,IEnumerable{TReference},Func{TReference,TObservation},Func{bool})"/>
+        /// <inheritdoc
+        ///     cref="ListBelief{TReference,TObservation}(Metadata,IEnumerable{TReference},System.Func{TReference,TObservation},System.Func{bool})"/>
         public ListBelief
         (
             IEnumerable<TReference> references,
-            Func<TReference, TObservation> getObservationFromReference,
-            Func<bool> shouldUpdate
+            System.Func<TReference, TObservation> getObservationFromReference,
+            System.Func<bool> shouldUpdate
         )
             : this(new Metadata(), references, getObservationFromReference, shouldUpdate)
         {
         }
 
         /// <inheritdoc
-        ///     cref="ListBelief{TReference,TObservation}(Metadata,IEnumerable{TReference},Func{TReference,TObservation},Func{bool})" />
+        ///     cref="ListBelief{TReference,TObservation}(Metadata,IEnumerable{TReference},System.Func{TReference,TObservation},System.Func{bool})" />
         public ListBelief
         (
             Metadata metadata,
             IEnumerable<TReference> references,
-            Func<TReference, TObservation> getObservationFromReference
+            System.Func<TReference, TObservation> getObservationFromReference
         )
             : this(metadata, references, getObservationFromReference, () => true)
         {
         }
 
         /// <inheritdoc
-        ///     cref="ListBelief{TReference,TObservation}(Metadata,IEnumerable{TReference},Func{TReference,TObservation},Func{bool})" />
+        ///     cref="ListBelief{TReference,TObservation}(Metadata,IEnumerable{TReference},System.Func{TReference,TObservation},System.Func{bool})" />
         public ListBelief
-            (IEnumerable<TReference> references, Func<TReference, TObservation> getObservationFromReference)
+            (IEnumerable<TReference> references, System.Func<TReference, TObservation> getObservationFromReference)
             : this(new Metadata(), references, getObservationFromReference, () => true)
         {
         }

--- a/Aplib.Core/Belief/Beliefs/MemoryBelief.cs
+++ b/Aplib.Core/Belief/Beliefs/MemoryBelief.cs
@@ -1,5 +1,4 @@
 using Aplib.Core.Collections;
-using System;
 
 namespace Aplib.Core.Belief.Beliefs
 {
@@ -44,36 +43,37 @@ namespace Aplib.Core.Belief.Beliefs
         /// <param name="shouldUpdate">
         /// A function that sets a condition on when the observation should be updated.
         /// </param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// Thrown when <paramref name="reference"/> is not a reference type.
         /// </exception>
         public MemoryBelief(
             Metadata metadata,
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int framesToRemember,
-            Func<bool> shouldUpdate
+            System.Func<bool> shouldUpdate
         )
             : base(metadata, reference, getObservationFromReference, shouldUpdate)
             => _memorizedObservations = new ExposedQueue<TObservation>(framesToRemember);
 
-        /// <inheritdoc cref="MemoryBelief{TReference,TObservation}(Metadata,TReference,Func{TReference,TObservation},int,Func{bool})"/>
+        /// <inheritdoc
+        ///     cref="MemoryBelief{TReference,TObservation}(Metadata,TReference,System.Func{TReference,TObservation},int,System.Func{bool})"/>
         public MemoryBelief(
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int framesToRemember,
-            Func<bool> shouldUpdate
+            System.Func<bool> shouldUpdate
         )
             : this(new Metadata(), reference, getObservationFromReference, framesToRemember, shouldUpdate)
         {
         }
 
         /// <inheritdoc
-        ///     cref="MemoryBelief{TReference,TObservation}(Metadata,TReference,Func{TReference,TObservation},int,Func{bool})" />
+        ///     cref="MemoryBelief{TReference,TObservation}(Metadata,TReference,System.Func{TReference,TObservation},int,System.Func{bool})" />
         public MemoryBelief(
             Metadata metadata,
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int framesToRemember
         )
             : this(metadata, reference, getObservationFromReference, framesToRemember, () => true)
@@ -81,9 +81,9 @@ namespace Aplib.Core.Belief.Beliefs
         }
 
         /// <inheritdoc
-        ///     cref="MemoryBelief{TReference,TObservation}(Metadata,TReference,Func{TReference,TObservation},int,Func{bool})" />
+        ///     cref="MemoryBelief{TReference,TObservation}(Metadata,TReference,System.Func{TReference,TObservation},int,System.Func{bool})" />
         public MemoryBelief(TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int framesToRemember)
             : this(new Metadata(), reference, getObservationFromReference, framesToRemember, () => true)
         {
@@ -118,9 +118,10 @@ namespace Aplib.Core.Belief.Beliefs
         {
             int lastMemoryIndex = _memorizedObservations.Count - 1;
             if (clamp)
-                index = Math.Clamp(index, 0, lastMemoryIndex);
+                index = System.Math.Clamp(index, 0, lastMemoryIndex);
             else if (index < 0 || index > lastMemoryIndex)
-                throw new ArgumentOutOfRangeException(nameof(index), $"Index must be between 0 and {lastMemoryIndex}.");
+                throw new System.ArgumentOutOfRangeException
+                    (nameof(index), $"Index must be between 0 and {lastMemoryIndex}.");
             return _memorizedObservations[index];
         }
 

--- a/Aplib.Core/Belief/Beliefs/SampledMemoryBelief.cs
+++ b/Aplib.Core/Belief/Beliefs/SampledMemoryBelief.cs
@@ -1,4 +1,3 @@
-using System;
 using static Aplib.Core.Belief.Beliefs.UpdateMode;
 
 namespace Aplib.Core.Belief.Beliefs
@@ -70,18 +69,18 @@ namespace Aplib.Core.Belief.Beliefs
         /// <param name="shouldUpdate">
         /// A function that sets a condition on when the observation should be updated.
         /// </param>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="System.ArgumentException">
         /// Thrown when <paramref name="reference"/> is not a reference type.
         /// </exception>
         public SampledMemoryBelief
         (
             Metadata metadata,
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int sampleInterval,
             UpdateMode updateMode,
             int framesToRemember,
-            Func<bool> shouldUpdate
+            System.Func<bool> shouldUpdate
         )
             : base(metadata, reference, getObservationFromReference, framesToRemember, shouldUpdate)
         {
@@ -90,15 +89,15 @@ namespace Aplib.Core.Belief.Beliefs
         }
 
         /// <inheritdoc
-        ///     cref="SampledMemoryBelief{TReference,TObservation}(Metadata,TReference,Func{TReference,TObservation},int,UpdateMode,int,Func{bool})" />
+        ///     cref="SampledMemoryBelief{TReference,TObservation}(Metadata,TReference,System.Func{TReference,TObservation},int,UpdateMode,int,System.Func{bool})" />
         public SampledMemoryBelief
         (
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int sampleInterval,
             UpdateMode updateMode,
             int framesToRemember,
-            Func<bool> shouldUpdate
+            System.Func<bool> shouldUpdate
         )
             : this
             (
@@ -114,12 +113,12 @@ namespace Aplib.Core.Belief.Beliefs
         }
 
         /// <inheritdoc
-        ///     cref="SampledMemoryBelief{TReference,TObservation}(Metadata,TReference,Func{TReference,TObservation},int,UpdateMode,int,Func{bool})" />
+        ///     cref="SampledMemoryBelief{TReference,TObservation}(Metadata,TReference,System.Func{TReference,TObservation},int,UpdateMode,int,System.Func{bool})" />
         public SampledMemoryBelief
         (
             Metadata metadata,
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int sampleInterval,
             UpdateMode updateMode,
             int framesToRemember
@@ -138,11 +137,11 @@ namespace Aplib.Core.Belief.Beliefs
         }
 
         /// <inheritdoc
-        ///     cref="SampledMemoryBelief{TReference,TObservation}(Metadata,TReference,Func{TReference,TObservation},int,UpdateMode,int,Func{bool})" />
+        ///     cref="SampledMemoryBelief{TReference,TObservation}(Metadata,TReference,System.Func{TReference,TObservation},int,UpdateMode,int,System.Func{bool})" />
         public SampledMemoryBelief
         (
             TReference reference,
-            Func<TReference, TObservation> getObservationFromReference,
+            System.Func<TReference, TObservation> getObservationFromReference,
             int sampleInterval,
             UpdateMode updateMode,
             int framesToRemember

--- a/Aplib.Core/Collections/ExposedQueue.cs
+++ b/Aplib.Core/Collections/ExposedQueue.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Aplib.Core.Collections
 {
@@ -55,16 +53,17 @@ namespace Aplib.Core.Collections
         /// The array will be copied to the queue, and the head will be set to the last element of the array.
         /// This method expects the array to be filled.
         /// </remarks>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when the max count is negative.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when the max count is negative.</exception>
         public ExposedQueue(T[] array, int maxCount)
         {
-            if (maxCount < 0) throw new ArgumentOutOfRangeException(nameof(maxCount), "Count cannot be negative.");
+            if (maxCount < 0)
+                throw new System.ArgumentOutOfRangeException(nameof(maxCount), "Count cannot be negative.");
 
             MaxCount = maxCount;
-            Count = Math.Min(array.Length, maxCount);
+            Count = System.Math.Min(array.Length, maxCount);
 
             _array = new T[maxCount];
-            Array.Copy(array, _array, Count);
+            System.Array.Copy(array, _array, Count);
 
             _head = Count - 1;
         }
@@ -80,19 +79,19 @@ namespace Aplib.Core.Collections
         /// </summary>
         /// <param name="index">The index of the element to get.</param>
         /// <returns>The element at the specified index.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the index is out of range.
         /// </exception>
         public T this[int index]
         {
             get
             {
-                if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index));
+                if (index < 0 || index >= Count) throw new System.ArgumentOutOfRangeException(nameof(index));
                 return _array[(index + _head + 1) % MaxCount];
             }
             private set
             {
-                if (index < 0 || index >= Count) throw new ArgumentOutOfRangeException(nameof(index));
+                if (index < 0 || index >= Count) throw new System.ArgumentOutOfRangeException(nameof(index));
                 _array[(index + _head + 1) % MaxCount] = value;
             }
         }
@@ -134,10 +133,10 @@ namespace Aplib.Core.Collections
         /// <returns>The ExposedQueue as a regular array.</returns>
         public void CopyTo(T[] array, int arrayIndex, int endIndex)
         {
-            if (arrayIndex < 0 || arrayIndex >= Count) throw new ArgumentOutOfRangeException(nameof(arrayIndex));
-            if (endIndex < 0 || endIndex >= Count) throw new ArgumentOutOfRangeException(nameof(endIndex));
+            if (arrayIndex < 0 || arrayIndex >= Count) throw new System.ArgumentOutOfRangeException(nameof(arrayIndex));
+            if (endIndex < 0 || endIndex >= Count) throw new System.ArgumentOutOfRangeException(nameof(endIndex));
             if (arrayIndex > endIndex)
-                throw new ArgumentException("Start index must be less than or equal to end index.");
+                throw new System.ArgumentException("Start index must be less than or equal to end index.");
 
             for (int i = 0; i < endIndex - arrayIndex + 1; i++) array[i] = this[arrayIndex + i];
         }
@@ -154,11 +153,12 @@ namespace Aplib.Core.Collections
         public T[] ToArray(int start, int end)
         {
             if (start < 0 || start >= Count)
-                throw new ArgumentOutOfRangeException(nameof(start),
+                throw new System.ArgumentOutOfRangeException(nameof(start),
                     "Start index must be within the bounds of the array."
                 );
             if (end < 0 || end >= Count)
-                throw new ArgumentOutOfRangeException(nameof(end), "End index must be within the bounds of the array.");
+                throw new System.ArgumentOutOfRangeException
+                    (nameof(end), "End index must be within the bounds of the array.");
             T[] result = new T[end - start + 1];
             CopyTo(result, start, end);
             return result;

--- a/Aplib.Core/Combinators.cs
+++ b/Aplib.Core/Combinators.cs
@@ -61,15 +61,15 @@ namespace Aplib.Core
 
         #region Tactic combinators
 
-        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
         public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>
-            (IMetadata metadata, System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (IMetadata metadata, System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             where TBeliefSet : IBeliefSet =>
             new(metadata, guard, subTactics);
 
-        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
         public static AnyOfTactic<TBeliefSet> AnyOf<TBeliefSet>
-            (System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             where TBeliefSet : IBeliefSet =>
             new(guard, subTactics);
 
@@ -84,15 +84,15 @@ namespace Aplib.Core
             where TBeliefSet : IBeliefSet =>
             new(subTactics);
 
-        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
         public static FirstOfTactic<TBeliefSet> FirstOf<TBeliefSet>
-            (IMetadata metadata, System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (IMetadata metadata, System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             where TBeliefSet : IBeliefSet =>
             new(metadata, guard, subTactics);
 
-        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
         public static FirstOfTactic<TBeliefSet> FirstOf<TBeliefSet>
-            (System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             where TBeliefSet : IBeliefSet =>
             new(guard, subTactics);
 
@@ -107,15 +107,15 @@ namespace Aplib.Core
             where TBeliefSet : IBeliefSet =>
             new(subTactics);
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
-            (IMetadata metadata, IAction<TBeliefSet> action, System.Func<TBeliefSet, bool> guard)
+            (IMetadata metadata, IAction<TBeliefSet> action, System.Predicate<TBeliefSet> guard)
             where TBeliefSet : IBeliefSet =>
             new(metadata, action, guard);
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IAction{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
-            (IAction<TBeliefSet> action, System.Func<TBeliefSet, bool> guard)
+            (IAction<TBeliefSet> action, System.Predicate<TBeliefSet> guard)
             where TBeliefSet : IBeliefSet =>
             new(action, guard);
 
@@ -130,15 +130,15 @@ namespace Aplib.Core
             new(action);
 
         /// <inheritdoc
-        ///     cref="PrimitiveTactic{TBeliefSet}(IMetadata,IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        ///     cref="PrimitiveTactic{TBeliefSet}(IMetadata,IQueryable{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
-            (IMetadata metadata, IQueryable<TBeliefSet> query, System.Func<TBeliefSet, bool> guard)
+            (IMetadata metadata, IQueryable<TBeliefSet> query, System.Predicate<TBeliefSet> guard)
             where TBeliefSet : IBeliefSet =>
             new(metadata, query, guard);
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public static PrimitiveTactic<TBeliefSet> Primitive<TBeliefSet>
-            (IQueryable<TBeliefSet> query, System.Func<TBeliefSet, bool> guard)
+            (IQueryable<TBeliefSet> query, System.Predicate<TBeliefSet> guard)
             where TBeliefSet : IBeliefSet =>
             new(query, guard);
 

--- a/Aplib.Core/Desire/DesireSets/DesireSet.cs
+++ b/Aplib.Core/Desire/DesireSets/DesireSet.cs
@@ -25,7 +25,7 @@ namespace Aplib.Core.Desire.DesireSets
         /// All active goal structures of the agent that still need to be finished are pushed on the stack.
         /// </summary>
         private readonly OptimizedActivationStack
-            <(IGoalStructure<TBeliefSet> goalStructure, System.Func<TBeliefSet, bool> guard)> _goalStructureStack;
+            <(IGoalStructure<TBeliefSet> goalStructure, System.Predicate<TBeliefSet> guard)> _goalStructureStack;
 
         /// <summary>
         /// If there are no goal structures left to be completed, the status of this desire set is set to the main goal status.
@@ -44,7 +44,7 @@ namespace Aplib.Core.Desire.DesireSets
         public DesireSet(
             IMetadata metadata,
             IGoalStructure<TBeliefSet> mainGoal,
-            params (IGoalStructure<TBeliefSet> goalStructure, System.Func<TBeliefSet, bool> guard)[] sideGoals
+            params (IGoalStructure<TBeliefSet> goalStructure, System.Predicate<TBeliefSet> guard)[] sideGoals
         )
         {
             Metadata = metadata;
@@ -55,15 +55,10 @@ namespace Aplib.Core.Desire.DesireSets
             _goalStructureStack.Activate(new((_mainGoal, _ => false), _goalStructureStack));
         }
 
-        /// <inheritdoc>
-        ///     <cref>
-        ///         DesireSet{TBeliefSet}(IMetadata,IGoalStructure{TBeliefSet},(IGoalStructure{TBeliefSet},
-        ///         System.Func{TBeliefSet,bool})[])
-        ///     </cref>
-        /// </inheritdoc>
+        /// <inheritdoc />
         public DesireSet(
             IGoalStructure<TBeliefSet> mainGoal,
-            params (IGoalStructure<TBeliefSet> goalStructure, System.Func<TBeliefSet, bool> guard)[] sideGoals
+            params (IGoalStructure<TBeliefSet> goalStructure, System.Predicate<TBeliefSet> guard)[] sideGoals
         ) : this(new Metadata(), mainGoal, sideGoals)
         { }
 

--- a/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
@@ -1,6 +1,5 @@
 using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Desire.Goals;
-using System;
 using System.Collections.Generic;
 
 namespace Aplib.Core.Desire.GoalStructures
@@ -12,7 +11,7 @@ namespace Aplib.Core.Desire.GoalStructures
     /// The children of this goal structure will be executed in the order they are given.
     /// </remarks>
     /// <typeparam name="TBeliefSet">The beliefset of the agent.</typeparam>
-    public class FirstOfGoalStructure<TBeliefSet> : GoalStructure<TBeliefSet>, IDisposable
+    public class FirstOfGoalStructure<TBeliefSet> : GoalStructure<TBeliefSet>, System.IDisposable
         where TBeliefSet : IBeliefSet
     {
         private readonly IEnumerator<IGoalStructure<TBeliefSet>> _childrenEnumerator;
@@ -76,7 +75,7 @@ namespace Aplib.Core.Desire.GoalStructures
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
+            System.GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/Aplib.Core/Desire/GoalStructures/PrimitiveGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/PrimitiveGoalStructure.cs
@@ -1,6 +1,5 @@
 using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Desire.Goals;
-using System;
 
 namespace Aplib.Core.Desire.GoalStructures
 {
@@ -26,7 +25,7 @@ namespace Aplib.Core.Desire.GoalStructures
         /// </param>
         /// <param name="goal">The goal to fulfill.</param>
         public PrimitiveGoalStructure(IMetadata metadata, IGoal<TBeliefSet> goal)
-            : base(metadata, Array.Empty<IGoalStructure<TBeliefSet>>()) => _goal = goal;
+            : base(metadata, System.Array.Empty<IGoalStructure<TBeliefSet>>()) => _goal = goal;
 
         /// <inheritdoc cref="PrimitiveGoalStructure{TBeliefSet}(IMetadata,IGoal{TBeliefSet})"/>
         public PrimitiveGoalStructure(IGoal<TBeliefSet> goal) : this(new Metadata(), goal) { }
@@ -35,7 +34,10 @@ namespace Aplib.Core.Desire.GoalStructures
         public override IGoal<TBeliefSet> GetCurrentGoal(TBeliefSet beliefSet) => _goal;
 
         /// <inheritdoc />
-        public override void UpdateStatus(TBeliefSet beliefSet) =>
-            Status = _goal.GetStatus(beliefSet);
+        public override void UpdateStatus(TBeliefSet beliefSet)
+        {
+            _goal.UpdateStatus(beliefSet);
+            Status = _goal.Status;
+        }
     }
 }

--- a/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
@@ -1,6 +1,5 @@
 using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Desire.Goals;
-using System;
 using System.Collections.Generic;
 
 namespace Aplib.Core.Desire.GoalStructures
@@ -13,7 +12,7 @@ namespace Aplib.Core.Desire.GoalStructures
     /// All goals must be completed in order for the goal structure to be completed.
     /// </remarks>
     /// <typeparam name="TBeliefSet">The type of belief set that this goal structure operates on.</typeparam>
-    public class SequentialGoalStructure<TBeliefSet> : GoalStructure<TBeliefSet>, IDisposable
+    public class SequentialGoalStructure<TBeliefSet> : GoalStructure<TBeliefSet>, System.IDisposable
         where TBeliefSet : IBeliefSet
     {
         /// <summary>
@@ -32,7 +31,7 @@ namespace Aplib.Core.Desire.GoalStructures
             : base(metadata, children)
         {
             if (children.Length <= 0)
-                throw new ArgumentException("Collection of children is empty", nameof(children));
+                throw new System.ArgumentException("Collection of children is empty", nameof(children));
 
             _childrenEnumerator = _children.GetEnumerator();
             _childrenEnumerator.MoveNext();
@@ -89,7 +88,7 @@ namespace Aplib.Core.Desire.GoalStructures
         public void Dispose()
         {
             Dispose(true);
-            GC.SuppressFinalize(this);
+            System.GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/Aplib.Core/Desire/Goals/CommonHeuristicFunctions.cs
+++ b/Aplib.Core/Desire/Goals/CommonHeuristicFunctions.cs
@@ -1,5 +1,4 @@
 using Aplib.Core.Belief.BeliefSets;
-using System;
 
 namespace Aplib.Core.Desire.Goals
 {
@@ -16,7 +15,7 @@ namespace Aplib.Core.Desire.Goals
         /// A heuristic function which returns true only when the state is considered completed.
         /// </param>
         /// <returns>A heuristic function which wraps around the boolean-based heuristic function.</returns>
-        public static Goal<TBeliefSet>.HeuristicFunction Boolean(Func<TBeliefSet, bool> heuristicFunction)
+        public static Goal<TBeliefSet>.HeuristicFunction Boolean(System.Predicate<TBeliefSet> heuristicFunction)
             => beliefSet => Heuristics.Boolean(heuristicFunction.Invoke(beliefSet));
 
         /// <summary>

--- a/Aplib.Core/Desire/Goals/CommonHeuristicFunctions.cs
+++ b/Aplib.Core/Desire/Goals/CommonHeuristicFunctions.cs
@@ -37,6 +37,6 @@ namespace Aplib.Core.Desire.Goals
         /// can be seen as NOT completed.
         /// </summary>
         /// <returns>Said heuristic function.</returns>
-        public static Goal<TBeliefSet>.HeuristicFunction Uncompleted() => Constant(69_420f);
+        public static Goal<TBeliefSet>.HeuristicFunction Uncompleted() => Constant(float.PositiveInfinity);
     }
 }

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -190,19 +190,27 @@ namespace Aplib.Core.Desire.Goals
             => _heuristicFunction.Invoke(beliefSet);
 
         /// <summary>
-        /// Tests whether the goal has been achieved, based on the heuristic function of the goal.
+        /// <para>Tests whether the goal has been achieved.</para>
+        /// <para>
+        /// This first checks the fail-guard of the goal, if it is true, the goal is considered to have failed.
+        /// </para>
+        /// <para>
+        /// If the fail guard is false, this checks the heuristic function of the goal.
         /// When the distance of the heuristics is smaller than <see cref="_epsilon" />,
         /// the goal is considered to be completed.
+        /// </para>
+        /// <para>Otherwise, the goal is considered unfinished.</para>
+        /// <para>Use <see cref="Status"/> to get the updated value.</para>
         /// </summary>
-        /// <returns>
-        /// A <see cref="CompletionStatus"/> value representing whether the goal is complete and if so,
-        /// with what result.
-        /// </returns>
+        /// <seealso cref="Status"/>
         public virtual void UpdateStatus(TBeliefSet beliefSet)
         {
-            Status = DetermineCurrentHeuristics(beliefSet).Distance < _epsilon
-                ? CompletionStatus.Success
-                : CompletionStatus.Unfinished;
+            if (_failGuard(beliefSet))
+                Status = CompletionStatus.Failure;
+            else if (DetermineCurrentHeuristics(beliefSet).Distance < _epsilon)
+                Status = CompletionStatus.Success;
+            else
+                Status = CompletionStatus.Unfinished;
         }
     }
 }

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -26,6 +26,10 @@ namespace Aplib.Core.Desire.Goals
         /// </summary>
         protected readonly double _epsilon;
 
+        /// <summary>
+        /// A fail-guard for the goal's completion status.
+        /// The fail-guard predicate is a condition that, when true, indicates that the goal has failed.
+        /// </summary>
         protected readonly System.Predicate<TBeliefSet> _failGuard;
 
         /// <summary>
@@ -60,16 +64,19 @@ namespace Aplib.Core.Desire.Goals
         public CompletionStatus Status { get; protected set; }
 
         /// <summary>
-        /// Creates a new goal which works with <see cref="Heuristics" />.
+        /// Initializes a new goal from a given tactic and heuristic function, and an optional fail-guard.
         /// </summary>
         /// <param name="metadata">
         /// Metadata about this goal, used to quickly display the goal in several contexts.
+        /// If omitted, default metadata will be generated.
         /// </param>
         /// <param name="tactic">The tactic used to approach this goal.</param>
         /// <param name="heuristicFunction">The heuristic function which defines whether a goal is reached.</param>
+        /// <param name="failGuard">
+        /// A predicate that determines when the goal has failed. If omitted, the goal will never fail.
+        /// </param>
         /// <param name="epsilon">
-        /// The goal is considered to be completed, when the distance of the <see cref="DetermineCurrentHeuristics" />
-        /// is below this value.
+        /// The goal is considered to be completed when the result of the heuristic function is below this value.
         /// </param>
         public Goal
         (
@@ -122,18 +129,19 @@ namespace Aplib.Core.Desire.Goals
         }
 
         /// <summary>
-        /// Creates a new goal which works with boolean-based <see cref="Heuristics" />.
+        /// Initializes a new goal from a given tactic and a success predicate, and an optional fail-guard.
         /// </summary>
         /// <param name="metadata">
         /// Metadata about this goal, used to quickly display the goal in several contexts.
+        /// If omitted, default metadata will be generated.
         /// </param>
         /// <param name="tactic">The tactic used to approach this goal.</param>
-        /// <param name="predicate">
-        /// The heuristic function (or specifically predicate) which defines whether a goal is reached.
+        /// <param name="predicate">A predicate that determines when the goal has succeeded.</param>
+        /// <param name="failGuard">
+        /// A predicate that determines when the goal has failed. If omitted, the goal will never fail.
         /// </param>
         /// <param name="epsilon">
-        /// The goal is considered to be completed, when the distance of the <see cref="DetermineCurrentHeuristics" />
-        /// is below this value.
+        /// The goal is considered to be completed when the result of the heuristic function is below this value.
         /// </param>
         public Goal
         (

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -186,12 +186,14 @@ namespace Aplib.Core.Desire.Goals
             => _heuristicFunction.Invoke(beliefSet);
 
         /// <summary>
-        /// Tests whether the goal has been achieved, bases on the <see cref="_heuristicFunction" /> and the
-        /// <see cref="DetermineCurrentHeuristics" />. When the distance of the heuristics is smaller than <see cref="_epsilon" />,
+        /// Tests whether the goal has been achieved, based on the heuristic function of the goal.
+        /// When the distance of the heuristics is smaller than <see cref="_epsilon" />,
         /// the goal is considered to be completed.
         /// </summary>
-        /// <returns>An enum representing whether the goal is complete and if so, with what result.</returns>
-        /// <seealso cref="_epsilon" />
+        /// <returns>
+        /// A <see cref="CompletionStatus"/> value representing whether the goal is complete and if so,
+        /// with what result.
+        /// </returns>
         public virtual CompletionStatus GetStatus(TBeliefSet beliefSet)
         {
             Status = DetermineCurrentHeuristics(beliefSet).Distance < _epsilon

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -26,6 +26,8 @@ namespace Aplib.Core.Desire.Goals
         /// </summary>
         protected readonly double _epsilon;
 
+        protected readonly System.Predicate<TBeliefSet> _failGuard;
+
         /// <summary>
         /// The concrete implementation of this Goal's <see cref="HeuristicFunction" />. Used to test whether this goal is
         /// completed.
@@ -70,19 +72,48 @@ namespace Aplib.Core.Desire.Goals
             IMetadata metadata,
             ITactic<TBeliefSet> tactic,
             HeuristicFunction heuristicFunction,
+            System.Predicate<TBeliefSet> failGuard,
             double epsilon = DefaultEpsilon
         )
         {
             Metadata = metadata;
             Tactic = tactic;
             _heuristicFunction = heuristicFunction;
+            _failGuard = failGuard;
             _epsilon = epsilon;
         }
 
-        /// <inheritdoc
-        ///     cref="Goal{TBeliefSet}(Aplib.Core.IMetadata,ITactic{TBeliefSet},Aplib.Core.Desire.Goals.Goal{TBeliefSet}.HeuristicFunction,double)" />
-        public Goal(ITactic<TBeliefSet> tactic, HeuristicFunction heuristicFunction, double epsilon = DefaultEpsilon)
-            : this(new Metadata(), tactic, heuristicFunction, epsilon)
+        /// <inheritdoc />
+        public Goal
+        (
+            ITactic<TBeliefSet> tactic,
+            HeuristicFunction heuristicFunction,
+            System.Predicate<TBeliefSet> failGuard,
+            double epsilon = DefaultEpsilon
+        )
+            : this(new Metadata(), tactic, heuristicFunction, failGuard, epsilon)
+        {
+        }
+
+        /// <inheritdoc />
+        public Goal
+        (
+            IMetadata metadata,
+            ITactic<TBeliefSet> tactic,
+            HeuristicFunction heuristicFunction,
+            double epsilon = DefaultEpsilon
+        ) : this(metadata, tactic, heuristicFunction, _ => false, epsilon)
+        {
+        }
+
+        /// <inheritdoc />
+        public Goal
+        (
+            ITactic<TBeliefSet> tactic,
+            HeuristicFunction heuristicFunction,
+            double epsilon = DefaultEpsilon
+        )
+            : this(tactic, heuristicFunction, _ => false, epsilon)
         {
         }
 
@@ -105,15 +136,45 @@ namespace Aplib.Core.Desire.Goals
             IMetadata metadata,
             ITactic<TBeliefSet> tactic,
             System.Predicate<TBeliefSet> predicate,
+            System.Predicate<TBeliefSet> failGuard,
             double epsilon = DefaultEpsilon
         )
-            : this(metadata, tactic, CommonHeuristicFunctions<TBeliefSet>.Boolean(predicate), epsilon)
+            : this(metadata, tactic, CommonHeuristicFunctions<TBeliefSet>.Boolean(predicate), failGuard, epsilon)
         {
         }
 
-        /// <inheritdoc cref="Goal{TBeliefSet}(Aplib.Core.IMetadata,ITactic{TBeliefSet},System.Predicate{TBeliefSet},double)" />
-        public Goal(ITactic<TBeliefSet> tactic, System.Predicate<TBeliefSet> predicate, double epsilon = DefaultEpsilon)
-            : this(new Metadata(), tactic, predicate, epsilon)
+        /// <inheritdoc />
+        public Goal
+        (
+            ITactic<TBeliefSet> tactic,
+            System.Predicate<TBeliefSet> predicate,
+            System.Predicate<TBeliefSet> failGuard,
+            double epsilon = DefaultEpsilon
+        )
+            : this(new Metadata(), tactic, predicate, failGuard, epsilon)
+        {
+        }
+
+        /// <inheritdoc />
+        public Goal
+        (
+            IMetadata metadata,
+            ITactic<TBeliefSet> tactic,
+            System.Predicate<TBeliefSet> predicate,
+            double epsilon = DefaultEpsilon
+        )
+            : this(metadata, tactic, predicate, _ => false, epsilon)
+        {
+        }
+
+        /// <inheritdoc />
+        public Goal
+        (
+            ITactic<TBeliefSet> tactic,
+            System.Predicate<TBeliefSet> predicate,
+            double epsilon = DefaultEpsilon
+        )
+            : this(tactic, predicate, _ => false, epsilon)
         {
         }
 

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -73,7 +73,10 @@ namespace Aplib.Core.Desire.Goals
         /// <param name="tactic">The tactic used to approach this goal.</param>
         /// <param name="heuristicFunction">The heuristic function which defines whether a goal is reached.</param>
         /// <param name="failGuard">
-        /// A predicate that determines when the goal has failed. If omitted, the goal will never fail.
+        /// A predicate that determines when the goal has failed.
+        /// If the fail-guard is true,
+        /// but the success heuristic is also satisfied, the success heuristic takes precedence.
+        /// If omitted, the goal will never fail.
         /// </param>
         /// <param name="epsilon">
         /// The goal is considered to be completed when the result of the heuristic function is below this value.
@@ -138,7 +141,10 @@ namespace Aplib.Core.Desire.Goals
         /// <param name="tactic">The tactic used to approach this goal.</param>
         /// <param name="predicate">A predicate that determines when the goal has succeeded.</param>
         /// <param name="failGuard">
-        /// A predicate that determines when the goal has failed. If omitted, the goal will never fail.
+        /// A predicate that determines when the goal has failed.
+        /// If the fail-guard is true,
+        /// but the success predicate is also satisfied, the success predicate takes precedence.
+        /// If omitted, the goal will never fail.
         /// </param>
         /// <param name="epsilon">
         /// The goal is considered to be completed when the result of the heuristic function is below this value.
@@ -200,12 +206,13 @@ namespace Aplib.Core.Desire.Goals
         /// <summary>
         /// <para>Tests whether the goal has been achieved.</para>
         /// <para>
-        /// This first checks the fail-guard of the goal, if it is true, the goal is considered to have failed.
+        /// This first checks the heuristic function of the goal.
+        /// When the distance of the heuristics is smaller than the epsilon of the goal,
+        /// the goal is considered to be completed.
         /// </para>
         /// <para>
-        /// If the fail guard is false, this checks the heuristic function of the goal.
-        /// When the distance of the heuristics is smaller than <see cref="_epsilon" />,
-        /// the goal is considered to be completed.
+        /// If the heuristic function is not smaller than the epsilon, this checks the fail-guard of the goal.
+        /// If the fail guard returns <c>true</c>, the goal is considered to have failed.
         /// </para>
         /// <para>Otherwise, the goal is considered unfinished.</para>
         /// <para>Use <see cref="Status"/> to get the updated value.</para>
@@ -213,10 +220,10 @@ namespace Aplib.Core.Desire.Goals
         /// <seealso cref="Status"/>
         public virtual void UpdateStatus(TBeliefSet beliefSet)
         {
-            if (_failGuard(beliefSet))
-                Status = CompletionStatus.Failure;
-            else if (DetermineCurrentHeuristics(beliefSet).Distance < _epsilon)
+            if (DetermineCurrentHeuristics(beliefSet).Distance < _epsilon)
                 Status = CompletionStatus.Success;
+            else if (_failGuard(beliefSet))
+                Status = CompletionStatus.Failure;
             else
                 Status = CompletionStatus.Unfinished;
         }

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -32,14 +32,14 @@ namespace Aplib.Core.Desire.Goals
         /// The concrete implementation of this Goal's <see cref="HeuristicFunction" />. Used to test whether this goal is
         /// completed.
         /// </summary>
-        /// <seealso cref="GetStatus" />
+        /// <seealso cref="UpdateStatus" />
         protected readonly HeuristicFunction _heuristicFunction;
 
         /// <summary>
         /// The abstract definition of what is means to test the Goal's heuristic function. Returns <see cref="Heuristics" />, as
         /// they represent how close we are to matching the heuristic function, and if the goal is completed.
         /// </summary>
-        /// <seealso cref="Goal{TBeliefSet}.GetStatus" />
+        /// <seealso cref="Goal{TBeliefSet}.UpdateStatus" />
         public delegate Heuristics HeuristicFunction(TBeliefSet beliefSet);
 
         /// <inheritdoc />
@@ -52,7 +52,11 @@ namespace Aplib.Core.Desire.Goals
         /// </summary>
         public ITactic<TBeliefSet> Tactic { get; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets the completion status of the goal.
+        /// This value may need to be updated first using the <see cref="UpdateStatus"/> method.
+        /// </summary>
+        /// <seealso cref="UpdateStatus"/>
         public CompletionStatus Status { get; protected set; }
 
         /// <summary>
@@ -194,12 +198,11 @@ namespace Aplib.Core.Desire.Goals
         /// A <see cref="CompletionStatus"/> value representing whether the goal is complete and if so,
         /// with what result.
         /// </returns>
-        public virtual CompletionStatus GetStatus(TBeliefSet beliefSet)
+        public virtual void UpdateStatus(TBeliefSet beliefSet)
         {
             Status = DetermineCurrentHeuristics(beliefSet).Distance < _epsilon
                 ? CompletionStatus.Success
                 : CompletionStatus.Unfinished;
-            return Status;
         }
     }
 }

--- a/Aplib.Core/Desire/Goals/Goal.cs
+++ b/Aplib.Core/Desire/Goals/Goal.cs
@@ -1,7 +1,6 @@
 using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Desire.GoalStructures;
 using Aplib.Core.Intent.Tactics;
-using System;
 
 namespace Aplib.Core.Desire.Goals
 {
@@ -105,15 +104,15 @@ namespace Aplib.Core.Desire.Goals
         (
             IMetadata metadata,
             ITactic<TBeliefSet> tactic,
-            Func<TBeliefSet, bool> predicate,
+            System.Predicate<TBeliefSet> predicate,
             double epsilon = DefaultEpsilon
         )
             : this(metadata, tactic, CommonHeuristicFunctions<TBeliefSet>.Boolean(predicate), epsilon)
         {
         }
 
-        /// <inheritdoc cref="Goal{TBeliefSet}(Aplib.Core.IMetadata,ITactic{TBeliefSet},Func{TBeliefSet,bool},double)" />
-        public Goal(ITactic<TBeliefSet> tactic, Func<TBeliefSet, bool> predicate, double epsilon = DefaultEpsilon)
+        /// <inheritdoc cref="Goal{TBeliefSet}(Aplib.Core.IMetadata,ITactic{TBeliefSet},System.Predicate{TBeliefSet},double)" />
+        public Goal(ITactic<TBeliefSet> tactic, System.Predicate<TBeliefSet> predicate, double epsilon = DefaultEpsilon)
             : this(new Metadata(), tactic, predicate, epsilon)
         {
         }

--- a/Aplib.Core/Desire/Goals/IGoal.cs
+++ b/Aplib.Core/Desire/Goals/IGoal.cs
@@ -24,11 +24,9 @@ namespace Aplib.Core.Desire.Goals
 
         /// <summary>
         /// Tests whether the goal has been achieved, based on the heuristic function of the goal.
+        /// The new completion status can be accessed via the <see cref="ICompletable.Status"/> property.
         /// </summary>
-        /// <returns>
-        /// A <see cref="CompletionStatus"/> value representing whether the goal is complete and if so,
-        /// with what result.
-        /// </returns>
-        CompletionStatus GetStatus(TBeliefSet beliefSet);
+        /// <seealso cref="ICompletable.Status"/>
+        void UpdateStatus(TBeliefSet beliefSet);
     }
 }

--- a/Aplib.Core/Desire/Goals/IGoal.cs
+++ b/Aplib.Core/Desire/Goals/IGoal.cs
@@ -23,12 +23,12 @@ namespace Aplib.Core.Desire.Goals
         Heuristics DetermineCurrentHeuristics(TBeliefSet beliefSet);
 
         /// <summary>
-        /// Tests whether the goal has been achieved, based on the <see cref="Goal{TBeliefSet}._heuristicFunction" /> and the
-        /// <see cref="Goal{TBeliefSet}.DetermineCurrentHeuristics" />. When the distance of the heuristics is smaller than <see cref="Goal{TBeliefSet}._epsilon" />
-        /// , the goal is considered to be completed.
+        /// Tests whether the goal has been achieved, based on the heuristic function of the goal.
         /// </summary>
-        /// <returns>An enum representing whether the goal is complete and if so, with what result.</returns>
-        /// <seealso cref="Goal{TBeliefSet}._epsilon" />
+        /// <returns>
+        /// A <see cref="CompletionStatus"/> value representing whether the goal is complete and if so,
+        /// with what result.
+        /// </returns>
         CompletionStatus GetStatus(TBeliefSet beliefSet);
     }
 }

--- a/Aplib.Core/IMetadata.cs
+++ b/Aplib.Core/IMetadata.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Aplib.Core
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace Aplib.Core
         /// <summary>
         /// Gets the unique identifier of the instance.
         /// </summary>
-        public Guid Id { get; }
+        public System.Guid Id { get; }
 
         /// <summary>
         /// Gets the name used to display the instance.

--- a/Aplib.Core/Intent/Tactics/AnyOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/AnyOfTactic.cs
@@ -27,25 +27,25 @@ namespace Aplib.Core.Intent.Tactics
         public AnyOfTactic
         (
             IMetadata metadata,
-            System.Func<TBeliefSet, bool> guard,
+            System.Predicate<TBeliefSet> guard,
             params ITactic<TBeliefSet>[] subTactics
         )
             : base(metadata, guard) => _subTactics = new LinkedList<ITactic<TBeliefSet>>(subTactics);
 
-        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])"/>
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
         public AnyOfTactic
-            (System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             : this(new Metadata(), guard, subTactics)
         {
         }
 
-        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
         public AnyOfTactic(IMetadata metadata, params ITactic<TBeliefSet>[] subTactics)
             : this(metadata, _ => true, subTactics)
         {
         }
 
-        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])" />
+        /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
         public AnyOfTactic(params ITactic<TBeliefSet>[] subTactics)
             : this(new Metadata(), _ => true, subTactics)
         {

--- a/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
@@ -20,25 +20,25 @@ namespace Aplib.Core.Intent.Tactics
         /// <param name="guard">The guard condition.</param>
         /// <param name="subTactics">The list of subtactics.</param>
         public FirstOfTactic
-            (IMetadata metadata, System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (IMetadata metadata, System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             : base(metadata, guard, subTactics)
         {
         }
 
-        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])"/>
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
         public FirstOfTactic(IMetadata metadata, params ITactic<TBeliefSet>[] subTactics)
             : this(metadata, _ => true, subTactics)
         {
         }
 
-        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])"/>
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
         public FirstOfTactic
-            (System.Func<TBeliefSet, bool> guard, params ITactic<TBeliefSet>[] subTactics)
+            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
             : this(new Metadata(), guard, subTactics)
         {
         }
 
-        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool},ITactic{TBeliefSet}[])"/>
+        /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
         public FirstOfTactic(params ITactic<TBeliefSet>[] subTactics) : this(new Metadata(), _ => true, subTactics) { }
 
         /// <inheritdoc />

--- a/Aplib.Core/Intent/Tactics/PrimitiveTactic.cs
+++ b/Aplib.Core/Intent/Tactics/PrimitiveTactic.cs
@@ -24,19 +24,19 @@ namespace Aplib.Core.Intent.Tactics
         /// </param>
         /// <param name="action">The action of the primitive tactic.</param>
         /// <param name="guard">The guard of the primitive tactic.</param>
-        public PrimitiveTactic(IMetadata metadata, IAction<TBeliefSet> action, System.Func<TBeliefSet, bool> guard)
+        public PrimitiveTactic(IMetadata metadata, IAction<TBeliefSet> action, System.Predicate<TBeliefSet> guard)
             : base(metadata, guard) => _action = action;
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
-        public PrimitiveTactic(IAction<TBeliefSet> action, System.Func<TBeliefSet, bool> guard)
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Predicate{TBeliefSet})"/>
+        public PrimitiveTactic(IAction<TBeliefSet> action, System.Predicate<TBeliefSet> guard)
             : this(new Metadata(), action, guard)
         {
         }
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public PrimitiveTactic(IMetadata metadata, IAction<TBeliefSet> action) : this(metadata, action, _ => true) { }
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IMetadata,IAction{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public PrimitiveTactic(IAction<TBeliefSet> action) : this(new Metadata(), action, _ => true) { }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Aplib.Core.Intent.Tactics
         /// <param name="queryAction">The queryable action of the primitive tactic.</param>
         /// <param name="guard">The guard of the primitive tactic.</param>
         public PrimitiveTactic
-            (IMetadata metadata, IQueryable<TBeliefSet> queryAction, System.Func<TBeliefSet, bool> guard)
+            (IMetadata metadata, IQueryable<TBeliefSet> queryAction, System.Predicate<TBeliefSet> guard)
             : this
             (
                 metadata,
@@ -60,20 +60,20 @@ namespace Aplib.Core.Intent.Tactics
         }
 
         /// <inheritdoc
-        ///     cref="PrimitiveTactic{TBeliefSet}(IMetadata,IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
-        public PrimitiveTactic(IQueryable<TBeliefSet> queryAction, System.Func<TBeliefSet, bool> guard)
+        ///     cref="PrimitiveTactic{TBeliefSet}(IMetadata,IQueryable{TBeliefSet},System.Predicate{TBeliefSet})"/>
+        public PrimitiveTactic(IQueryable<TBeliefSet> queryAction, System.Predicate<TBeliefSet> guard)
             : this(new Metadata(), queryAction, guard)
         {
         }
 
-        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})" />
+        /// <inheritdoc cref="PrimitiveTactic{TBeliefSet}(IQueryable{TBeliefSet},System.Predicate{TBeliefSet})" />
         public PrimitiveTactic(IMetadata metadata, IQueryable<TBeliefSet> queryAction)
             : this(metadata, queryAction, _ => true)
         {
         }
 
         /// <inheritdoc
-        ///     cref="PrimitiveTactic{TBeliefSet}(IMetadata,IQueryable{TBeliefSet},System.Func{TBeliefSet,bool})"/>
+        ///     cref="PrimitiveTactic{TBeliefSet}(IMetadata,IQueryable{TBeliefSet},System.Predicate{TBeliefSet})"/>
         public PrimitiveTactic(IQueryable<TBeliefSet> queryAction)
             : this(new Metadata(), queryAction, _ => true)
         {

--- a/Aplib.Core/Intent/Tactics/Tactic.cs
+++ b/Aplib.Core/Intent/Tactics/Tactic.cs
@@ -18,7 +18,7 @@ namespace Aplib.Core.Intent.Tactics
         /// <summary>
         /// Gets or sets the guard of the tactic.
         /// </summary>
-        protected System.Func<TBeliefSet, bool> _guard;
+        protected readonly System.Predicate<TBeliefSet> _guard;
 
         /// <inheritdoc />
         public IMetadata Metadata { get; }
@@ -30,14 +30,14 @@ namespace Aplib.Core.Intent.Tactics
         /// Metadata about this tactic, used to quickly display the tactic in several contexts.
         /// </param>
         /// <param name="guard">The guard of the tactic.</param>
-        protected Tactic(IMetadata metadata, System.Func<TBeliefSet, bool> guard)
+        protected Tactic(IMetadata metadata, System.Predicate<TBeliefSet> guard)
         {
             _guard = guard;
             Metadata = metadata;
         }
 
-        /// <inheritdoc cref="Tactic{TBeliefSet}(IMetadata,System.Func{TBeliefSet,bool})" />
-        protected Tactic(System.Func<TBeliefSet, bool> guard) : this(new Metadata(), guard) { }
+        /// <inheritdoc cref="Tactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet})" />
+        protected Tactic(System.Predicate<TBeliefSet> guard) : this(new Metadata(), guard) { }
 
         /// <inheritdoc />
         protected Tactic(IMetadata metadata) : this(metadata, _ => true) { }

--- a/Aplib.Core/Metadata.cs
+++ b/Aplib.Core/Metadata.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Aplib.Core
 {
     /// <summary>
@@ -8,7 +6,7 @@ namespace Aplib.Core
     public class Metadata : IMetadata
     {
         /// <inheritdoc />
-        public Guid Id { get; }
+        public System.Guid Id { get; }
 
         /// <inheritdoc />
         public string? Name { get; }
@@ -21,7 +19,10 @@ namespace Aplib.Core
         /// </summary>
         /// <param name="name">The name used to display the component.</param>
         /// <param name="description">The description used to describe the component.</param>
-        public Metadata(string? name = null, string? description = null) : this(Guid.NewGuid(), name, description) { }
+        public Metadata(string? name = null, string? description = null)
+            : this(System.Guid.NewGuid(), name, description)
+        {
+        }
 
         /// <summary>
         /// Store information about a BDI cycle component which may be useful for debugging or logging or general overviews.
@@ -30,7 +31,7 @@ namespace Aplib.Core
         /// <param name="id">A unique identifier for the component.</param>
         /// <param name="name">The name used to display the component.</param>
         /// <param name="description">The description used to describe the component.</param>
-        internal Metadata(Guid id, string? name = null, string? description = null)
+        internal Metadata(System.Guid id, string? name = null, string? description = null)
         {
             Id = id;
             Name = name;

--- a/Aplib.Core/ThreadSafeRandom.cs
+++ b/Aplib.Core/ThreadSafeRandom.cs
@@ -1,14 +1,12 @@
-﻿using System;
-
-namespace Aplib.Core
+﻿namespace Aplib.Core
 {
     internal static class ThreadSafeRandom
     {
-        [ThreadStatic]
-        private static Random? _local;
-        private static readonly Random _global = new();
+        [System.ThreadStatic]
+        private static System.Random? _local;
+        private static readonly System.Random _global = new();
 
-        private static Random Instance
+        private static System.Random Instance
         {
             get
             {
@@ -20,7 +18,7 @@ namespace Aplib.Core
                         seed = _global.Next();
                     }
 
-                    _local = new Random(seed);
+                    _local = new System.Random(seed);
                 }
 
                 return _local;

--- a/Aplib.Extensions/IPathfinder.cs
+++ b/Aplib.Extensions/IPathfinder.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Aplib.Extensions
+﻿namespace Aplib.Extensions
 {
     /// <summary>
     /// Defines a pathfinding algorithm used to find a path from a starting point to an end point.
@@ -15,7 +13,7 @@ namespace Aplib.Extensions
         /// <param name="begin">The starting point of the path.</param>
         /// <param name="end">The end point of the path.</param>
         /// <returns>A read-only span of elements representing the path from the starting point to the end point.</returns>
-        public ReadOnlySpan<T> FindPath(T begin, T end);
+        public System.ReadOnlySpan<T> FindPath(T begin, T end);
 
         /// <summary>
         /// Gets the next step towards the specified end point from the current point in the path.


### PR DESCRIPTION
## Description

This PR adds a failure condition to the Goal class. The used can provide a fail-guard upon construction of the Goal. If no fail-guard is provided, the goal will never fail.

The fail-guard is checked in de UpdateStatus method of the goal, before the heuristic. Thus, failure takes precedence over success.

This PR also changed all usages of `System.Func<T, bool>` to `System.Predicate<T>`, which is more semantically accurate.

And this PR also changes the `GetStatus` method in `IGoal` to `UpdateStatus` to be in line with other classes/interfaces implementing the `ICompletable` interface.

Lastly, this PR removes all remaining imports of the plain `System` namespace from the project, to avoid collision between `System.Action` and `Aplib.Core.Intent.Actions.Action`.

## Breaking change

- Because a `System.Func<T, bool>` cannot be implicitly converted to a `System.Predicate<T>`.
- Because the `GetStatus` method is replaced by `UpdateStatus`.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch