### PR TITLE
fix!: make `SequentialGoalStructure` and `FirstOfGoalStructure` resettable

### DIFF
--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -374,6 +374,27 @@ public class GoalStructureTests
     }
 
     [Fact]
+    public void RepeatGoalStructure_WhenReset_ShouldBeUnfinished()
+    {
+        // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
+
+        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);
+
+        repeatGoalStructure.UpdateStatus(beliefSet);
+
+        // Act
+        repeatGoalStructure.Reset();
+
+        // Assert
+        repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
+    }
+
+    [Fact]
     public void ReusedGoalStructures_WhenSequenced_ShouldNotBeFinished()
     {
         // Arrange

--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -374,25 +374,6 @@ public class GoalStructureTests
     }
 
     [Fact]
-    public void RepeatGoalStructure_WhenReset_ShouldBeUnfinished()
-    {
-        // Arrange
-        Mock<IGoalStructure<IBeliefSet>> goalStructure = new();
-        goalStructure.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
-
-        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
-        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(goalStructure.Object);
-
-        repeatGoalStructure.UpdateStatus(beliefSet);
-
-        // Act
-        repeatGoalStructure.Reset();
-
-        // Assert
-        repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
-    }
-
-    [Fact]
     public void ReusedGoalStructures_WhenSequenced_ShouldNotBeFinished()
     {
         // Arrange

--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -160,6 +160,44 @@ public class GoalStructureTests
     }
 
     [Fact]
+    public void FirstOfGoalStructure_WhenReset_ShouldResetChildren()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+
+        Mock<FirstOfGoalStructure<IBeliefSet>> firstOfGoalStructure
+            = new(goalStructure1.Object, goalStructure2.Object) { CallBase = true };
+
+        // Act
+        firstOfGoalStructure.Object.Reset();
+
+        // Assert
+        goalStructure1.Verify(x => x.Reset(), Times.Once);
+        goalStructure2.Verify(x => x.Reset(), Times.Once);
+    }
+
+    [Fact]
+    public void FirstOfGoalStructure_WhenReset_ShouldBeUnfinished()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        goalStructure1.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+        goalStructure2.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+        FirstOfGoalStructure<IBeliefSet> firstOfGoalStructure = new(goalStructure1.Object, goalStructure2.Object);
+
+        // Act
+        firstOfGoalStructure.UpdateStatus(beliefSet);
+        firstOfGoalStructure.Reset();
+
+        // Assert
+        firstOfGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
+    }
+
+    [Fact]
     public void PrimitiveGoalStructure_ConstructedWithMetadata_HasCorrectMetadata()
     {
         // Arrange
@@ -209,6 +247,25 @@ public class GoalStructureTests
 
         // Assert
         currentGoal.Should().Be(goal.Object);
+    }
+
+
+    [Fact]
+    public void PrimitiveGoalStructure_WhenReset_ShouldBeUnfinished()
+    {
+        // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
+
+        // Act
+        primitiveGoalStructure.UpdateStatus(beliefSet);
+        primitiveGoalStructure.Reset();
+
+        // Assert
+        primitiveGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
     }
 
     [Fact]
@@ -299,6 +356,39 @@ public class GoalStructureTests
 
         // Assert
         primitiveGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
+    }
+
+    [Fact]
+    public void RepeatGoalStructure_WhenReset_ShouldResetInnerGoalStructure()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> innerGoalStructure = new();
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(innerGoalStructure.Object);
+
+        // Act
+        repeatGoalStructure.Reset();
+
+        // Assert
+        innerGoalStructure.Verify(x => x.Reset(), Times.Once);
+    }
+
+
+    [Fact]
+    public void RepeatGoalStructure_WhenReset_ShouldBeUnfinished()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure = new();
+        goalStructure.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(goalStructure.Object);
+
+        // Act
+        repeatGoalStructure.UpdateStatus(beliefSet);
+        repeatGoalStructure.Reset();
+
+        // Assert
+        repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
     }
 
     [Fact]
@@ -460,5 +550,44 @@ public class GoalStructureTests
 
         // Assert
         act.Should().Throw<System.ArgumentException>();
+    }
+
+    [Fact]
+    public void SequentialGoalStructure_WhenReset_ShouldResetChildren()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+
+        Mock<SequentialGoalStructure<IBeliefSet>> sequentialGoalStructure
+            = new(goalStructure1.Object, goalStructure2.Object) { CallBase = true };
+
+        // Act
+        sequentialGoalStructure.Object.Reset();
+
+        // Assert
+        goalStructure1.Verify(x => x.Reset(), Times.Once);
+        goalStructure2.Verify(x => x.Reset(), Times.Once);
+    }
+
+
+    [Fact]
+    public void SequentialGoalStructure_WhenReset_ShouldBeUnfinished()
+    {
+        // Arrange
+        Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
+        goalStructure1.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+        Mock<IGoalStructure<IBeliefSet>> goalStructure2 = new();
+        goalStructure2.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
+
+        IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
+        SequentialGoalStructure<IBeliefSet> sequentialGoalStructure = new(goalStructure1.Object, goalStructure2.Object);
+
+        // Act
+        sequentialGoalStructure.UpdateStatus(beliefSet);
+        sequentialGoalStructure.Reset();
+
+        // Assert
+        sequentialGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
     }
 }

--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -191,6 +191,9 @@ public class GoalStructureTests
 
         firstOfGoalStructure.UpdateStatus(beliefSet);
 
+        // Pre-conditions
+        firstOfGoalStructure.Status.Should().Be(CompletionStatus.Success);
+
         // Act
         firstOfGoalStructure.Reset();
 
@@ -261,8 +264,12 @@ public class GoalStructureTests
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
 
-        // Act
         primitiveGoalStructure.UpdateStatus(beliefSet);
+
+        // Pre-conditions
+        primitiveGoalStructure.Status.Should().Be(CompletionStatus.Success);
+
+        // Act
         primitiveGoalStructure.Reset();
 
         // Assert
@@ -386,6 +393,11 @@ public class GoalStructureTests
 
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(goalStructure.Object);
+
+        repeatGoalStructure.UpdateStatus(beliefSet);
+
+        // Pre-conditions
+        repeatGoalStructure.Status.Should().Be(CompletionStatus.Success);
 
         // Act
         repeatGoalStructure.Reset();
@@ -587,6 +599,9 @@ public class GoalStructureTests
         SequentialGoalStructure<IBeliefSet> sequentialGoalStructure = new(goalStructure1.Object, goalStructure2.Object);
 
         sequentialGoalStructure.UpdateStatus(beliefSet);
+
+        // Pre-conditions
+        sequentialGoalStructure.Status.Should().Be(CompletionStatus.Success);
 
         // Act
         sequentialGoalStructure.Reset();

--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -189,8 +189,9 @@ public class GoalStructureTests
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         FirstOfGoalStructure<IBeliefSet> firstOfGoalStructure = new(goalStructure1.Object, goalStructure2.Object);
 
-        // Act
         firstOfGoalStructure.UpdateStatus(beliefSet);
+
+        // Act
         firstOfGoalStructure.Reset();
 
         // Assert
@@ -260,8 +261,9 @@ public class GoalStructureTests
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
 
-        // Act
         primitiveGoalStructure.UpdateStatus(beliefSet);
+
+        // Act
         primitiveGoalStructure.Reset();
 
         // Assert
@@ -342,20 +344,19 @@ public class GoalStructureTests
     }
 
     [Fact]
-    public void RepeatGoalStructure_WhenInnerGoalStructureHasFailed_InnerGoalStructureShouldBeUnfinished()
+    public void RepeatGoalStructure_WhenInnerGoalStructureHasFailed_ShouldBeUnfinished()
     {
         // Arrange
-        Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.Status).Returns(CompletionStatus.Failure);
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
-        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
-        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);
+        Mock<IGoalStructure<IBeliefSet>> innerGoalStructure = new();
+        innerGoalStructure.Setup(g => g.Status).Returns(CompletionStatus.Failure);
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(innerGoalStructure.Object);
 
         // Act
         repeatGoalStructure.UpdateStatus(beliefSet);
 
         // Assert
-        primitiveGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
+        repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
     }
 
     [Fact]
@@ -372,7 +373,6 @@ public class GoalStructureTests
         innerGoalStructure.Verify(x => x.Reset(), Times.Once);
     }
 
-
     [Fact]
     public void RepeatGoalStructure_WhenReset_ShouldBeUnfinished()
     {
@@ -383,8 +383,9 @@ public class GoalStructureTests
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(goalStructure.Object);
 
-        // Act
         repeatGoalStructure.UpdateStatus(beliefSet);
+
+        // Act
         repeatGoalStructure.Reset();
 
         // Assert
@@ -583,8 +584,9 @@ public class GoalStructureTests
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         SequentialGoalStructure<IBeliefSet> sequentialGoalStructure = new(goalStructure1.Object, goalStructure2.Object);
 
-        // Act
         sequentialGoalStructure.UpdateStatus(beliefSet);
+
+        // Act
         sequentialGoalStructure.Reset();
 
         // Assert

--- a/Aplib.Core.Tests/Desire/GoalStructureTests.cs
+++ b/Aplib.Core.Tests/Desire/GoalStructureTests.cs
@@ -178,7 +178,7 @@ public class GoalStructureTests
     }
 
     [Fact]
-    public void FirstOfGoalStructure_WhenReset_ShouldBeUnfinished()
+    public void FirstOfGoalStructure_WhenResetAfterFinished_ShouldBeUnfinished()
     {
         // Arrange
         Mock<IGoalStructure<IBeliefSet>> goalStructure1 = new();
@@ -261,9 +261,8 @@ public class GoalStructureTests
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
         PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
 
-        primitiveGoalStructure.UpdateStatus(beliefSet);
-
         // Act
+        primitiveGoalStructure.UpdateStatus(beliefSet);
         primitiveGoalStructure.Reset();
 
         // Assert
@@ -347,13 +346,18 @@ public class GoalStructureTests
     public void RepeatGoalStructure_WhenInnerGoalStructureHasFailed_ShouldBeUnfinished()
     {
         // Arrange
+        Mock<IGoal<IBeliefSet>> goal = new();
+        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
+
+        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
+
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
-        Mock<IGoalStructure<IBeliefSet>> innerGoalStructure = new();
-        innerGoalStructure.Setup(g => g.Status).Returns(CompletionStatus.Failure);
-        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(innerGoalStructure.Object);
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);
+
+        repeatGoalStructure.UpdateStatus(beliefSet);
 
         // Act
-        repeatGoalStructure.UpdateStatus(beliefSet);
+        repeatGoalStructure.Reset();
 
         // Assert
         repeatGoalStructure.Status.Should().Be(CompletionStatus.Unfinished);
@@ -377,15 +381,11 @@ public class GoalStructureTests
     public void RepeatGoalStructure_WhenReset_ShouldBeUnfinished()
     {
         // Arrange
-        Mock<IGoal<IBeliefSet>> goal = new();
-        goal.Setup(g => g.Status).Returns(CompletionStatus.Success);
-
-        PrimitiveGoalStructure<IBeliefSet> primitiveGoalStructure = new(goal.Object);
+        Mock<IGoalStructure<IBeliefSet>> goalStructure = new();
+        goalStructure.SetupGet(g => g.Status).Returns(CompletionStatus.Success);
 
         IBeliefSet beliefSet = Mock.Of<IBeliefSet>();
-        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(primitiveGoalStructure);
-
-        repeatGoalStructure.UpdateStatus(beliefSet);
+        RepeatGoalStructure<IBeliefSet> repeatGoalStructure = new(goalStructure.Object);
 
         // Act
         repeatGoalStructure.Reset();

--- a/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
@@ -41,7 +41,7 @@ namespace Aplib.Core.Desire.GoalStructures
         /// <summary>
         /// Updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
         /// The goal structure status is set to:
-        /// <list type="table">
+        /// <list type="bullet">
         ///     <item>
         ///         <term><see cref="Success"/></term>
         ///         <description>When any one of its children is successful.</description>

--- a/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
@@ -1,11 +1,12 @@
 using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Desire.Goals;
 using System.Collections.Generic;
+using static Aplib.Core.CompletionStatus;
 
 namespace Aplib.Core.Desire.GoalStructures
 {
     /// <summary>
-    /// Represents a goal structure that will complete if any of its children complete.
+    /// Represents a goal structure that will complete if any one of its children completes.
     /// </summary>
     /// <remarks>
     /// The children of this goal structure will be executed in the order they are given.
@@ -37,38 +38,48 @@ namespace Aplib.Core.Desire.GoalStructures
         public override IGoal<TBeliefSet> GetCurrentGoal(TBeliefSet beliefSet)
             => _currentGoalStructure!.GetCurrentGoal(beliefSet);
 
-        /// <inheritdoc />
+        /// <summary>
+        /// This method updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
+        /// The goal structure status is set to:
+        /// <list type="table">
+        /// <item>
+        /// <term><see cref="Success"/></term>
+        /// <term>When any one of its children is successful.</term>
+        /// </item>
+        /// <item>
+        /// <term><see cref="Failure"/></term>
+        /// <term>When all children fail.</term>
+        /// </item>
+        /// <item>
+        /// <term><see cref="Unfinished"/></term>
+        /// <term>Otherwise.</term>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="beliefSet">The belief set of the agent.</param>
         public override void UpdateStatus(TBeliefSet beliefSet)
         {
-            // Loop through all the children until one of them is unfinished or successful.
-            // This loop is here to prevent tail recursion.
-            while (true)
+            if (Status != Unfinished) return;
+
+            // Loop through all the children until one of them is unfinished or successful,
+            // or the end of the enumerator is reached.
+            do
             {
-                if (Status == CompletionStatus.Success) return;
-
+                _currentGoalStructure = _childrenEnumerator.Current;
                 _currentGoalStructure!.UpdateStatus(beliefSet);
-
-                switch (_currentGoalStructure.Status)
-                {
-                    case CompletionStatus.Unfinished:
-                        return;
-                    case CompletionStatus.Success:
-                        Status = CompletionStatus.Success;
-                        return;
-                }
-
-                if (_childrenEnumerator.MoveNext())
-                {
-                    _currentGoalStructure = _childrenEnumerator.Current;
-                    Status = CompletionStatus.Unfinished;
-
-                    // Update the Status of the new goal structure
-                    continue;
-                }
-
-                Status = CompletionStatus.Failure;
-                return;
             }
+            while (_currentGoalStructure.Status == Failure && _childrenEnumerator.MoveNext());
+
+            Status = _currentGoalStructure.Status;
+        }
+
+        /// <inheritdoc />
+        public override void Reset()
+        {
+            base.Reset();
+
+            _childrenEnumerator.Reset();
+            _childrenEnumerator.MoveNext();
         }
 
         /// <inheritdoc />

--- a/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/FirstOfGoalStructure.cs
@@ -39,21 +39,21 @@ namespace Aplib.Core.Desire.GoalStructures
             => _currentGoalStructure!.GetCurrentGoal(beliefSet);
 
         /// <summary>
-        /// This method updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
+        /// Updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
         /// The goal structure status is set to:
         /// <list type="table">
-        /// <item>
-        /// <term><see cref="Success"/></term>
-        /// <term>When any one of its children is successful.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Failure"/></term>
-        /// <term>When all children fail.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Unfinished"/></term>
-        /// <term>Otherwise.</term>
-        /// </item>
+        ///     <item>
+        ///         <term><see cref="Success"/></term>
+        ///         <description>When any one of its children is successful.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="Failure"/></term>
+        ///         <description>When all children fail.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="Unfinished"/></term>
+        ///         <description>Otherwise.</description>
+        ///     </item>
         /// </list>
         /// </summary>
         /// <param name="beliefSet">The belief set of the agent.</param>

--- a/Aplib.Core/Desire/GoalStructures/GoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/GoalStructure.cs
@@ -19,7 +19,7 @@ namespace Aplib.Core.Desire.GoalStructures
         protected readonly IEnumerable<IGoalStructure<TBeliefSet>> _children;
 
         /// <inheritdoc />
-        public CompletionStatus Status { get; protected set; }
+        public CompletionStatus Status { get; protected set; } = CompletionStatus.Unfinished;
 
         /// <summary>
         /// The goal structure that is currently being fulfilled.
@@ -54,6 +54,14 @@ namespace Aplib.Core.Desire.GoalStructures
         /// </summary>
         /// <param name="beliefSet">The belief set of the agent.</param>
         public abstract void UpdateStatus(TBeliefSet beliefSet);
+
+        /// <inheritdoc />
+        public virtual void Reset()
+        {
+            foreach (IGoalStructure<TBeliefSet> child in _children) child.Reset();
+
+            Status = CompletionStatus.Unfinished;
+        }
 
         /// <summary>
         /// Implicitly lifts a goal into a goal structure.

--- a/Aplib.Core/Desire/GoalStructures/IGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/IGoalStructure.cs
@@ -25,5 +25,10 @@ namespace Aplib.Core.Desire.GoalStructures
         /// </summary>
         /// <param name="beliefSet">The belief set of the agent.</param>
         void UpdateStatus(TBeliefSet beliefSet);
+
+        /// <summary>
+        /// Resets the goal structure to its initial state.
+        /// </summary>
+        void Reset();
     }
 }

--- a/Aplib.Core/Desire/GoalStructures/PrimitiveGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/PrimitiveGoalStructure.cs
@@ -34,8 +34,8 @@ namespace Aplib.Core.Desire.GoalStructures
         public override IGoal<TBeliefSet> GetCurrentGoal(TBeliefSet beliefSet) => _goal;
 
         /// <summary>
-        /// This method updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
-        /// The goal structure status is set to the status of the underlying <see cref="IGoal{TBeliefSet}"/>.
+        /// Updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
+        /// The goal structure status is set to the status of the underlying <see cref="IGoal{TBeliefSet}" />.
         /// </summary>
         /// <param name="beliefSet">The belief set of the agent.</param>
         public override void UpdateStatus(TBeliefSet beliefSet)

--- a/Aplib.Core/Desire/GoalStructures/PrimitiveGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/PrimitiveGoalStructure.cs
@@ -33,7 +33,11 @@ namespace Aplib.Core.Desire.GoalStructures
         /// <inheritdoc />
         public override IGoal<TBeliefSet> GetCurrentGoal(TBeliefSet beliefSet) => _goal;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// This method updates the status of the <see cref="FirstOfGoalStructure{TBeliefSet}" />.
+        /// The goal structure status is set to the status of the underlying <see cref="IGoal{TBeliefSet}"/>.
+        /// </summary>
+        /// <param name="beliefSet">The belief set of the agent.</param>
         public override void UpdateStatus(TBeliefSet beliefSet)
         {
             _goal.UpdateStatus(beliefSet);

--- a/Aplib.Core/Desire/GoalStructures/RepeatGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/RepeatGoalStructure.cs
@@ -35,24 +35,24 @@ namespace Aplib.Core.Desire.GoalStructures
 
 
         /// <summary>
-        /// This method updates the status of the <see cref="RepeatGoalStructure{TBeliefSet}" />.
+        /// Updates the status of the <see cref="RepeatGoalStructure{TBeliefSet}" />.
         /// The goal structure status is set to:
         /// <list type="table">
-        /// <item>
-        /// <term><see cref="Success"/></term>
-        /// <term>When the underlying <see cref="IGoalStructure{TBeliefSet}"/> is successful.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Failure"/></term>
-        /// <term>Never.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Unfinished"/></term>
-        /// <term>
-        /// When the underlying <see cref="IGoalStructure{TBeliefSet}"/> is unfinished.
-        /// The goal structure will continue to execute the underlying goal structure until it is successful.
-        /// </term>
-        /// </item>
+        ///     <item>
+        ///         <term><see cref="Success"/></term>
+        ///         <description>When the underlying goal structure is successful.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="Failure"/></term>
+        ///         <description>Never.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="Unfinished"/></term>
+        ///         <description>
+        ///             When the underlying goal structure is unfinished.
+        ///             The underlying goal structure will be retried when it fails.
+        ///         </description>
+        ///     </item>
         /// </list>
         /// </summary>
         /// <param name="beliefSet">The belief set of the agent.</param>

--- a/Aplib.Core/Desire/GoalStructures/RepeatGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/RepeatGoalStructure.cs
@@ -37,7 +37,7 @@ namespace Aplib.Core.Desire.GoalStructures
         /// <summary>
         /// Updates the status of the <see cref="RepeatGoalStructure{TBeliefSet}" />.
         /// The goal structure status is set to:
-        /// <list type="table">
+        /// <list type="bullet">
         ///     <item>
         ///         <term><see cref="Success"/></term>
         ///         <description>When the underlying goal structure is successful.</description>

--- a/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
@@ -48,21 +48,21 @@ namespace Aplib.Core.Desire.GoalStructures
             => _currentGoalStructure!.GetCurrentGoal(beliefSet);
 
         /// <summary>
-        /// This method updates the status of the <see cref="SequentialGoalStructure{TBeliefSet}" />.
+        /// Updates the status of the <see cref="SequentialGoalStructure{TBeliefSet}" />.
         /// The goal structure status is set to:
         /// <list type="table">
-        /// <item>
-        /// <term><see cref="Success"/></term>
-        /// <term>When all children are successful.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Failure"/></term>
-        /// <term>When any one of its children fails.</term>
-        /// </item>
-        /// <item>
-        /// <term><see cref="Unfinished"/></term>
-        /// <term>Otherwise.</term>
-        /// </item>
+        ///     <item>
+        ///         <term><see cref="Success"/></term>
+        ///         <description>When all children are successful.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="Failure"/></term>
+        ///         <description>When any one of its children fails.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="Unfinished"/></term>
+        ///         <description>Otherwise.</description>
+        ///     </item>
         /// </list>
         /// </summary>
         /// <param name="beliefSet">The belief set of the agent.</param>

--- a/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
@@ -1,15 +1,15 @@
 using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Desire.Goals;
 using System.Collections.Generic;
+using static Aplib.Core.CompletionStatus;
 
 namespace Aplib.Core.Desire.GoalStructures
 {
     /// <summary>
-    /// Represents a sequential goal structure.
+    /// Represents a goal structure that will complete if all of its children complete.
     /// </summary>
     /// <remarks>
-    /// This class is a specific type of goal structure where goals are processed sequentially.
-    /// All goals must be completed in order for the goal structure to be completed.
+    /// The children of this goal structure will be executed in the order they are given.
     /// </remarks>
     /// <typeparam name="TBeliefSet">The type of belief set that this goal structure operates on.</typeparam>
     public class SequentialGoalStructure<TBeliefSet> : GoalStructure<TBeliefSet>, System.IDisposable
@@ -47,41 +47,48 @@ namespace Aplib.Core.Desire.GoalStructures
         public override IGoal<TBeliefSet> GetCurrentGoal(TBeliefSet beliefSet)
             => _currentGoalStructure!.GetCurrentGoal(beliefSet);
 
-        /// <inheritdoc />
+        /// <summary>
+        /// This method updates the status of the <see cref="SequentialGoalStructure{TBeliefSet}" />.
+        /// The goal structure status is set to:
+        /// <list type="table">
+        /// <item>
+        /// <term><see cref="Success"/></term>
+        /// <term>When all children are successful.</term>
+        /// </item>
+        /// <item>
+        /// <term><see cref="Failure"/></term>
+        /// <term>When any one of its children fails.</term>
+        /// </item>
+        /// <item>
+        /// <term><see cref="Unfinished"/></term>
+        /// <term>Otherwise.</term>
+        /// </item>
+        /// </list>
+        /// </summary>
+        /// <param name="beliefSet">The belief set of the agent.</param>
         public override void UpdateStatus(TBeliefSet beliefSet)
         {
-            // Loop through all the children until one of them is unfinished or successful.
-            // This loop is here to prevent tail recursion.
-            while (true)
+            if (Status != Unfinished) return;
+
+            // Loop through all the children until one of them is unfinished or failed,
+            // or the end of the enumerator is reached.
+            do
             {
-                if (Status == CompletionStatus.Success) return;
-
+                _currentGoalStructure = _childrenEnumerator.Current;
                 _currentGoalStructure!.UpdateStatus(beliefSet);
-
-                switch (_currentGoalStructure.Status)
-                {
-                    case CompletionStatus.Unfinished:
-                        return;
-                    case CompletionStatus.Failure:
-                        Status = CompletionStatus.Failure;
-                        return;
-                    case CompletionStatus.Success:
-                    default:
-                        break;
-                }
-
-                if (_childrenEnumerator.MoveNext())
-                {
-                    _currentGoalStructure = _childrenEnumerator.Current;
-                    Status = CompletionStatus.Unfinished;
-
-                    // Update the state of the new goal structure
-                    continue;
-                }
-
-                Status = CompletionStatus.Success;
-                return;
             }
+            while (_currentGoalStructure.Status == Success && _childrenEnumerator.MoveNext());
+
+            Status = _currentGoalStructure.Status;
+        }
+
+        /// <inheritdoc />
+        public override void Reset()
+        {
+            base.Reset();
+
+            _childrenEnumerator.Reset();
+            _childrenEnumerator.MoveNext();
         }
 
         /// <inheritdoc />

--- a/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
+++ b/Aplib.Core/Desire/GoalStructures/SequentialGoalStructure.cs
@@ -50,7 +50,7 @@ namespace Aplib.Core.Desire.GoalStructures
         /// <summary>
         /// Updates the status of the <see cref="SequentialGoalStructure{TBeliefSet}" />.
         /// The goal structure status is set to:
-        /// <list type="table">
+        /// <list type="bullet">
         ///     <item>
         ///         <term><see cref="Success"/></term>
         ///         <description>When all children are successful.</description>


### PR DESCRIPTION
## Description
This PR aims to fix a problem with `RepeatGoalStructure`, where the inner goal structure would not be reset when it failed.
It also refactors the UpdateStatus methods of the goal structure subclasses.

## Testability
Run tests.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch