### PR TITLE
refactor: make `FirstOfTactic` derive `Tactic`

### DIFF
--- a/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
+++ b/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
@@ -34,7 +34,7 @@ public class TacticTests
     {
         public System.Predicate<IBeliefSet> Guard => _guard;
 
-        public LinkedList<ITactic<IBeliefSet>> SubTactics => _subTactics;
+        public LinkedList<ITactic<IBeliefSet>> Subtactics => _subtactics;
 
         public TestFirstOfTactic
             (Metadata metadata, System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subTactics)
@@ -201,7 +201,7 @@ public class TacticTests
         // Assert
         tactic.Metadata.Should().Be(metadata);
         tactic.Guard.Should().Be(guard);
-        tactic.SubTactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
     }
 
     [Fact]
@@ -217,7 +217,7 @@ public class TacticTests
         // Assert
         tactic.Metadata.Should().Be(metadata);
         tactic.Guard(It.IsAny<IBeliefSet>()).Should().BeTrue();
-        tactic.SubTactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public class TacticTests
         tactic.Metadata.Name.Should().BeNull();
         tactic.Metadata.Description.Should().BeNull();
         tactic.Guard.Should().Be(guard);
-        tactic.SubTactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class TacticTests
         tactic.Metadata.Name.Should().BeNull();
         tactic.Metadata.Description.Should().BeNull();
         tactic.Guard(It.IsAny<IBeliefSet>()).Should().BeTrue();
-        tactic.SubTactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
     }
 
     /// <summary>

--- a/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
+++ b/Aplib.Core.Tests/Intent/Tactics/TacticTests.cs
@@ -37,22 +37,22 @@ public class TacticTests
         public LinkedList<ITactic<IBeliefSet>> Subtactics => _subtactics;
 
         public TestFirstOfTactic
-            (Metadata metadata, System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subTactics)
-            : base(metadata, guard, subTactics)
+            (Metadata metadata, System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subtactics)
+            : base(metadata, guard, subtactics)
         {
         }
 
-        public TestFirstOfTactic(Metadata metadata, params ITactic<IBeliefSet>[] subTactics)
-            : base(metadata, subTactics)
+        public TestFirstOfTactic(Metadata metadata, params ITactic<IBeliefSet>[] subtactics)
+            : base(metadata, subtactics)
         {
         }
 
-        public TestFirstOfTactic(System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subTactics)
-            : base(guard, subTactics)
+        public TestFirstOfTactic(System.Predicate<IBeliefSet> guard, params ITactic<IBeliefSet>[] subtactics)
+            : base(guard, subtactics)
         {
         }
 
-        public TestFirstOfTactic(params ITactic<IBeliefSet>[] subTactics) : base(subTactics) { }
+        public TestFirstOfTactic(params ITactic<IBeliefSet>[] subtactics) : base(subtactics) { }
     }
 
 
@@ -193,15 +193,15 @@ public class TacticTests
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
         System.Predicate<IBeliefSet> guard = It.IsAny<System.Predicate<IBeliefSet>>();
-        ITactic<IBeliefSet>[] subTactics = [It.IsAny<ITactic<IBeliefSet>>()];
+        ITactic<IBeliefSet>[] subtactics = [It.IsAny<ITactic<IBeliefSet>>()];
 
         // Act
-        TestFirstOfTactic tactic = new(metadata, guard, subTactics);
+        TestFirstOfTactic tactic = new(metadata, guard, subtactics);
 
         // Assert
         tactic.Metadata.Should().Be(metadata);
         tactic.Guard.Should().Be(guard);
-        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subtactics);
     }
 
     [Fact]
@@ -209,15 +209,15 @@ public class TacticTests
     {
         // Arrange
         Metadata metadata = It.IsAny<Metadata>();
-        ITactic<IBeliefSet>[] subTactics = [It.IsAny<ITactic<IBeliefSet>>()];
+        ITactic<IBeliefSet>[] subtactics = [It.IsAny<ITactic<IBeliefSet>>()];
 
         // Act
-        TestFirstOfTactic tactic = new(metadata, subTactics);
+        TestFirstOfTactic tactic = new(metadata, subtactics);
 
         // Assert
         tactic.Metadata.Should().Be(metadata);
         tactic.Guard(It.IsAny<IBeliefSet>()).Should().BeTrue();
-        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subtactics);
     }
 
     [Fact]
@@ -225,34 +225,34 @@ public class TacticTests
     {
         // Arrange
         System.Predicate<IBeliefSet> guard = It.IsAny<System.Predicate<IBeliefSet>>();
-        ITactic<IBeliefSet>[] subTactics = [It.IsAny<ITactic<IBeliefSet>>()];
+        ITactic<IBeliefSet>[] subtactics = [It.IsAny<ITactic<IBeliefSet>>()];
 
         // Act
-        TestFirstOfTactic tactic = new(guard, subTactics);
+        TestFirstOfTactic tactic = new(guard, subtactics);
 
         // Assert
         tactic.Metadata.Id.Should().NotBeEmpty();
         tactic.Metadata.Name.Should().BeNull();
         tactic.Metadata.Description.Should().BeNull();
         tactic.Guard.Should().Be(guard);
-        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subtactics);
     }
 
     [Fact]
     public void FirstOfTacticTactic_WithoutMetadataWithoutGuard_HasExpectedData()
     {
         // Arrange
-        ITactic<IBeliefSet>[] subTactics = [It.IsAny<ITactic<IBeliefSet>>()];
+        ITactic<IBeliefSet>[] subtactics = [It.IsAny<ITactic<IBeliefSet>>()];
 
         // Act
-        TestFirstOfTactic tactic = new(subTactics);
+        TestFirstOfTactic tactic = new(subtactics);
 
         // Assert
         tactic.Metadata.Id.Should().NotBeEmpty();
         tactic.Metadata.Name.Should().BeNull();
         tactic.Metadata.Description.Should().BeNull();
         tactic.Guard(It.IsAny<IBeliefSet>()).Should().BeTrue();
-        tactic.Subtactics.Should().BeEquivalentTo(subTactics);
+        tactic.Subtactics.Should().BeEquivalentTo(subtactics);
     }
 
     /// <summary>

--- a/Aplib.Core/Intent/Tactics/AnyOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/AnyOfTactic.cs
@@ -7,49 +7,49 @@ using System.Linq;
 namespace Aplib.Core.Intent.Tactics
 {
     /// <summary>
-    /// Represents a tactic that executes any of the provided sub-tactics.
+    /// Represents a tactic that executes any of the provided subtactics.
     /// </summary>
     public class AnyOfTactic<TBeliefSet> : Tactic<TBeliefSet>
         where TBeliefSet : IBeliefSet
     {
         /// <summary>
-        /// Gets or sets the sub-tactics of the tactic.
+        /// Gets or sets the subtactics of the tactic.
         /// </summary>
-        protected readonly LinkedList<ITactic<TBeliefSet>> _subTactics;
+        protected internal readonly LinkedList<ITactic<TBeliefSet>> _subtactics;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AnyOfTactic{TBeliefSet}"/> class with the specified sub-tactics
+        /// Initializes a new instance of the <see cref="AnyOfTactic{TBeliefSet}"/> class with the specified subtactics
         /// and an optional guard condition.
         /// </summary>
         /// <param name="metadata">
         /// Metadata about this tactic, used to quickly display the tactic in several contexts.
         /// </param>
         /// <param name="guard">The guard condition.</param>
-        /// <param name="subTactics">The list of subtactics.</param>
+        /// <param name="subtactics">The list of subtactics.</param>
         public AnyOfTactic
         (
             IMetadata metadata,
             System.Predicate<TBeliefSet> guard,
-            params ITactic<TBeliefSet>[] subTactics
+            params ITactic<TBeliefSet>[] subtactics
         )
-            : base(metadata, guard) => _subTactics = new LinkedList<ITactic<TBeliefSet>>(subTactics);
+            : base(metadata, guard) => _subtactics = new LinkedList<ITactic<TBeliefSet>>(subtactics);
 
         /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
         public AnyOfTactic
-            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
-            : this(new Metadata(), guard, subTactics)
+            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subtactics)
+            : this(new Metadata(), guard, subtactics)
         {
         }
 
         /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
-        public AnyOfTactic(IMetadata metadata, params ITactic<TBeliefSet>[] subTactics)
-            : this(metadata, _ => true, subTactics)
+        public AnyOfTactic(IMetadata metadata, params ITactic<TBeliefSet>[] subtactics)
+            : this(metadata, _ => true, subtactics)
         {
         }
 
         /// <inheritdoc cref="AnyOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])" />
-        public AnyOfTactic(params ITactic<TBeliefSet>[] subTactics)
-            : this(new Metadata(), _ => true, subTactics)
+        public AnyOfTactic(params ITactic<TBeliefSet>[] subtactics)
+            : this(new Metadata(), _ => true, subtactics)
         {
         }
 
@@ -60,7 +60,7 @@ namespace Aplib.Core.Intent.Tactics
 
             List<IAction<TBeliefSet>> actions = new();
 
-            foreach (ITactic<TBeliefSet> subTactic in _subTactics)
+            foreach (ITactic<TBeliefSet> subTactic in _subtactics)
             {
                 IAction<TBeliefSet>? action = subTactic.GetAction(beliefSet);
 
@@ -73,6 +73,6 @@ namespace Aplib.Core.Intent.Tactics
         }
 
         /// <inheritdoc/>
-        public override IEnumerable<ILoggable> GetLogChildren() => _subTactics.OfType<ILoggable>();
+        public override IEnumerable<ILoggable> GetLogChildren() => _subtactics.OfType<ILoggable>();
     }
 }

--- a/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
@@ -1,55 +1,67 @@
 ﻿using Aplib.Core.Belief.BeliefSets;
 using Aplib.Core.Intent.Actions;
+using Aplib.Core.Logging;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Aplib.Core.Intent.Tactics
 {
     /// <summary>
-    /// Represents a tactic that executes the first enabled action from a list of sub-tactics.
+    /// Represents a tactic that executes the first enabled action from a list of subtactics.
     /// </summary>
-    public class FirstOfTactic<TBeliefSet> : AnyOfTactic<TBeliefSet>
+    public class FirstOfTactic<TBeliefSet> : Tactic<TBeliefSet>
         where TBeliefSet : IBeliefSet
     {
         /// <summary>
+        /// Gets or sets the subtactics of the tactic.
+        /// </summary>
+        protected readonly LinkedList<ITactic<TBeliefSet>> _subtactics;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="FirstOfTactic{TBeliefSet}"/> class with the specified
-        /// sub-tactics and guard condition.
+        /// subtactics and guard condition.
         /// </summary>
         /// <param name="metadata">
         /// Metadata about this tactic, used to quickly display the tactic in several contexts.
         /// </param>
         /// <param name="guard">The guard condition.</param>
-        /// <param name="subTactics">The list of subtactics.</param>
+        /// <param name="subtactics">The list of subtactics.</param>
         public FirstOfTactic
-            (IMetadata metadata, System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
-            : base(metadata, guard, subTactics)
-        {
-        }
+        (
+            IMetadata metadata,
+            System.Predicate<TBeliefSet> guard,
+            params ITactic<TBeliefSet>[] subtactics
+        )
+            : base(metadata, guard) => _subtactics = new LinkedList<ITactic<TBeliefSet>>(subtactics);
 
         /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
-        public FirstOfTactic(IMetadata metadata, params ITactic<TBeliefSet>[] subTactics)
-            : this(metadata, _ => true, subTactics)
+        public FirstOfTactic(IMetadata metadata, params ITactic<TBeliefSet>[] subtactics)
+            : this(metadata, _ => true, subtactics)
         {
         }
 
         /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
         public FirstOfTactic
-            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subTactics)
-            : this(new Metadata(), guard, subTactics)
+            (System.Predicate<TBeliefSet> guard, params ITactic<TBeliefSet>[] subtactics)
+            : this(new Metadata(), guard, subtactics)
         {
         }
 
         /// <inheritdoc cref="FirstOfTactic{TBeliefSet}(IMetadata,System.Predicate{TBeliefSet},ITactic{TBeliefSet}[])"/>
-        public FirstOfTactic(params ITactic<TBeliefSet>[] subTactics) : this(new Metadata(), _ => true, subTactics) { }
+        public FirstOfTactic(params ITactic<TBeliefSet>[] subtactics) : this(new Metadata(), _ => true, subtactics) { }
 
         /// <inheritdoc />
         public override IAction<TBeliefSet>? GetAction(TBeliefSet beliefSet)
         {
             if (!IsActionable(beliefSet)) return null;
 
-            return _subTactics
+            return _subtactics
                 .Select(subTactic => subTactic.GetAction(beliefSet))
                 .OfType<IAction<TBeliefSet>>()
                 .FirstOrDefault();
         }
+
+        /// <inheritdoc/>
+        public override IEnumerable<ILoggable> GetLogChildren() => _subtactics.OfType<ILoggable>();
     }
 }

--- a/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
+++ b/Aplib.Core/Intent/Tactics/FirstOfTactic.cs
@@ -15,7 +15,7 @@ namespace Aplib.Core.Intent.Tactics
         /// <summary>
         /// Gets or sets the subtactics of the tactic.
         /// </summary>
-        protected readonly LinkedList<ITactic<TBeliefSet>> _subtactics;
+        protected internal readonly LinkedList<ITactic<TBeliefSet>> _subtactics;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FirstOfTactic{TBeliefSet}"/> class with the specified


### PR DESCRIPTION
## Description
This PR aims to make the class hierarchy semantically correct by deriving FirstOfTactic from Tactic instead of AnyOfTactic.
Additionally, it makes the style of subtactic naming consistent.

## Testability
Run tests.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch